### PR TITLE
Adding cargo test, adding --quiet, and -qq to apt-get

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,11 @@ jobs:
         id: build
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -y install rustup pkg-config libssl-dev
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -y -qq install rustup pkg-config libssl-dev
           rustup toolchain install stable
       - name: Build
         run: |
-          cargo check
-          cargo build --release
+          cargo --quiet check
+          cargo test
+          cargo --quiet build --release
           ls -lha target/release


### PR DESCRIPTION
Integrating tests into CI

Now if a code change breaks the test, it should not be able to integrate via PR