### PR TITLE
Moving system information out of POC, updating core to use sysinfo.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ anyhow = "1.0"
 # Tokio / Async
 tokio = { version = "1", features = ["signal", "process", "macros", "rt-multi-thread"] }
 
-sys-info = "0.9.1"
-os_info = "3.12.0"
+sysinfo = "0.37"
 
 winapi = { version = "0.3", features = ["sysinfoapi"] }

--- a/waagent-core/Cargo.toml
+++ b/waagent-core/Cargo.toml
@@ -19,8 +19,7 @@ authors = [
 ]
 
 [dependencies]
-sys-info = { workspace = true }
-os_info = { workspace = true }
+sysinfo = { workspace = true }
 tracing = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/waagent-core/src/system.rs
+++ b/waagent-core/src/system.rs
@@ -1,4 +1,7 @@
 use sysinfo::System;
+use std::sync::OnceLock;
+
+static CACHED_SYSTEM_INFO: OnceLock<SystemInfo> = OnceLock::new();
 
 #[derive(Debug)]
 pub struct SystemInfo {
@@ -15,27 +18,47 @@ pub struct SystemStats {
 }
 
 impl SystemInfo {
-    pub fn current() -> Self {
-        let hostname = get_hostname();
-        let os_version = get_os_version();
-        let os_name = get_os_display_name();
+    pub fn current() -> &'static SystemInfo {
+        CACHED_SYSTEM_INFO.get_or_init(|| {
+            let hostname = get_hostname();
+            let os_version = get_os_version();
+            let os_name = get_os_display_name();
 
-        SystemInfo {
-            hostname,
-            os_name,
-            os_version,
-        }
+            SystemInfo {
+                hostname,
+                os_name,
+                os_version,
+            }
+        })
     }
 }
 
 impl SystemStats {
     pub fn current() -> Self {
-        let mut system = System::new_all();
-        system.refresh_all();
+        // Use System::new() instead of new_all() for faster initialization
+        let mut system = System::new();
+        system.refresh_cpu_all();
+        system.refresh_memory();
 
-        let cpu_usage = get_cpu_usage_percent();
-        let memory_usage = get_memory_usage_percent();
-        let uptime_seconds = get_uptime_seconds();
+        let cpu_usage = get_cpu_usage_percent_with(&system);
+        let memory_usage = get_memory_usage_percent_with(&system);
+        let uptime_seconds = get_uptime_seconds_with(&system);
+
+        SystemStats {
+            cpu_usage,
+            memory_usage,
+            uptime_seconds,
+        }
+    }
+
+    /// More efficient version when you have an existing System instance
+    pub fn from_system(system: &mut System) -> Self {
+        system.refresh_cpu_all();
+        system.refresh_memory();
+
+        let cpu_usage = get_cpu_usage_percent_with(system);
+        let memory_usage = get_memory_usage_percent_with(system);
+        let uptime_seconds = get_uptime_seconds_with(system);
 
         SystemStats {
             cpu_usage,
@@ -62,26 +85,25 @@ fn get_hostname() -> String {
     hostname.to_string()
 }
 
-fn get_cpu_usage_percent() -> f64 {
-    System::load_average().one
+fn get_cpu_usage_percent_with(system: &System) -> f64 {
+    // Use global CPU usage from the system
+    system.global_cpu_usage() as f64
 }
 
 // Get memory usage percentage
-fn get_memory_usage_percent() -> f64 {
-    let mut system = System::new_all();
-    system.refresh_all();
+fn get_memory_usage_percent_with(system: &System) -> f64 {
     let used = system.used_memory();
     let total = system.total_memory();
-    let usage_percent = (used as f64 / total as f64) * 100.0;
-    usage_percent
+    if total == 0 {
+        0.0
+    } else {
+        (used as f64 / total as f64) * 100.0
+    }
 }
 
 // Get OS display name
 fn get_os_display_name() -> String {
-    let mut system = System::new_all();
-    system.refresh_all();
-
-    // Get OS name using the static method
+    // Get OS name using the static method - no System instance needed
     let os_name = System::name().unwrap_or_else(|| "Linux".to_string()).to_lowercase();
 
     // Try to match known distributions
@@ -110,30 +132,8 @@ fn get_os_version() -> String {
 }
 
 // Get system uptime in seconds
-fn get_uptime_seconds() -> u64 {
-    #[cfg(all(not(unix), not(windows)))]
-    {
-        0
-    }
-
-    // Simple approximation using boot time
-    #[cfg(unix)]    
-    {
-        let mut system = System::new_all();
-        system.refresh_all();
-        System::uptime()
-    }
-
-    #[cfg(windows)]
-    {
-        use winapi::um::sysinfoapi::GetTickCount64;
-        
-        unsafe {
-            let uptime_ms = GetTickCount64();
-            let uptime_seconds = uptime_ms / 1000;
-            uptime_seconds
-        }
-    }
+fn get_uptime_seconds_with(_system: &System) -> u64 {
+    System::uptime()
 }
 
 // Unit tests for the system module
@@ -187,7 +187,9 @@ mod tests {
 
     #[test]
     fn test_get_cpu_usage_percent() {
-        let cpu_usage = get_cpu_usage_percent();
+        let mut system = System::new_all();
+        system.refresh_cpu_all();
+        let cpu_usage = get_cpu_usage_percent_with(&system);
         
         // Should return a valid float
         assert!(cpu_usage >= 0.0, "CPU usage should be non-negative");
@@ -198,7 +200,9 @@ mod tests {
 
     #[test]
     fn test_get_memory_usage_percent() {
-        let memory_usage = get_memory_usage_percent();
+        let mut system = System::new_all();
+        system.refresh_memory();
+        let memory_usage = get_memory_usage_percent_with(&system);
         
         // Should return a valid float
         assert!(memory_usage >= 0.0 && memory_usage <= 100.0, "Memory usage should be between 0 and 100");
@@ -234,7 +238,8 @@ mod tests {
 
     #[test]
     fn test_get_uptime_seconds() {
-        let uptime = get_uptime_seconds();
+        let system = System::new_all();
+        let uptime = get_uptime_seconds_with(&system);
         
         // Should return a valid u64 (non-negative by type)
         // In most cases, uptime should be greater than 0 (system has been running for some time)
@@ -279,6 +284,9 @@ mod tests {
         assert_eq!(info1.hostname, info2.hostname, "Hostname should be consistent");
         assert_eq!(info1.os_name, info2.os_name, "OS name should be consistent");
         assert_eq!(info1.os_version, info2.os_version, "OS version should be consistent");
+        
+        // Test that cached values are actually the same reference
+        assert!(std::ptr::eq(info1, info2), "SystemInfo should return cached instance");
     }
 
     #[test]

--- a/waagent-poc/Cargo.toml
+++ b/waagent-poc/Cargo.toml
@@ -12,5 +12,4 @@ base64 = "0.22"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 tokio = { version = "1.0", features = ["full"] }
 chrono = { version = "0.4", features = ["serde"] }
-sys-info = "0.9.1"
-os_info = "3.12.0"
+waagent-core = { path = "../waagent-core" }

--- a/waagent-poc/src/main.rs
+++ b/waagent-poc/src/main.rs
@@ -416,7 +416,6 @@ async fn run_heartbeat_loop(client: &Client, goal_state: &GoalState) -> Result<(
         
         match event_name {
             "HeartBeat" => {
-                //let sys_info = get_system_info();
                 let sys_info = SystemStats::current();
                 params.extend(vec![
                     Param {

--- a/waagent-poc/src/main.rs
+++ b/waagent-poc/src/main.rs
@@ -1,14 +1,14 @@
 use base64::prelude::*;
 use chrono::Utc;
-use os_info;
 use quick_xml::de::from_str;
 use quick_xml::se::to_string;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::process::Command;
 use std::time::Duration;
-use sys_info;
 use tokio::time::sleep;
+use waagent_core::system::SystemInfo;
+use waagent_core::system::SystemStats;
 
 // Constants
 const WIRESERVER_ENDPOINT: &str = "http://168.63.129.16";
@@ -34,82 +34,6 @@ fn get_user_agent() -> String {
     format!("{}/{}", AGENT_NAME, AGENT_VERSION)
 }
 
-fn get_system_info() -> SystemInfo {
-    let hostname = match sys_info::hostname() {
-        Ok(name) => name,
-        Err(e) => {
-            eprintln!("Warning: Failed to get hostname: {}", e);
-            "Undefined".to_string()
-        }
-    };
-    
-    SystemInfo {
-        hostname,
-        cpu_usage: get_cpu_usage_percent(),
-        memory_usage: get_memory_usage_percent(),
-        processor_time: get_processor_time(),
-    }
-}
-
-fn get_cpu_usage_percent() -> String {
-    // Get CPU load average as a simple approximation
-    match sys_info::loadavg() {
-        Ok(load) => format!("{:.1}", load.one * 100.0),
-        Err(_) => "0".to_string(),
-    }
-}
-
-fn get_memory_usage_percent() -> String {
-    match (sys_info::mem_info(), sys_info::mem_info()) {
-        (Ok(mem), _) => {
-            let used = mem.total - mem.free;
-            let usage_percent = (used as f64 / mem.total as f64) * 100.0;
-            format!("{:.1}", usage_percent)
-        }
-        _ => "0".to_string(),
-    }
-}
-
-fn get_processor_time() -> String {
-    // Just a quick patch for building on non *nix systems
-    #[cfg(not(unix))]
-    {
-        "0".to_string()
-    }
-
-    #[cfg(unix)]
-    {
-        // Simple approximation using boot time
-        match sys_info::boottime() {
-            Ok(boot_time) => {
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs();
-                let uptime = now.saturating_sub(boot_time.tv_sec as u64);
-                format!("{}", uptime)
-            }
-            Err(_) => "0".to_string(),
-        }
-    }
-}
-
-fn get_os_version(_sys_info: &SystemInfo) -> String {
-    let info = os_info::get();
-    
-    let version = info.version().to_string();
-    // There could be two bugs in os_info 3.12.0, if confirmed we need to move this comment
-    // to a doc in our repo, submit an issue and if possible submit a patch.
-    // version for ubuntu should return "24.04.3" but instead returns "24.4.0"
-    version
-}
-
-fn get_os_display_name() -> String {
-    let info = os_info::get();
-
-    let os_type = info.os_type().to_string().to_lowercase();
-    os_type
-}
 
 // Helper function to get the uid of a specific user
 fn get_user_uid(username: &str) -> Result<String> {
@@ -211,13 +135,6 @@ async fn add_wireserver_iptables_rule() -> Result<()> {
 }
 
 
-#[derive(Debug)]
-struct SystemInfo {
-    hostname: String,
-    cpu_usage: String,
-    memory_usage: String,
-    processor_time: String,
-}
 
 fn create_base_params(goal_state: &GoalState) -> Vec<Param> {
     vec![
@@ -499,7 +416,8 @@ async fn run_heartbeat_loop(client: &Client, goal_state: &GoalState) -> Result<(
         
         match event_name {
             "HeartBeat" => {
-                let sys_info = get_system_info();
+                //let sys_info = get_system_info();
+                let sys_info = SystemStats::current();
                 params.extend(vec![
                     Param {
                         name: "IsVersionFromRSM".to_string(),
@@ -515,15 +433,15 @@ async fn run_heartbeat_loop(client: &Client, goal_state: &GoalState) -> Result<(
                     },
                     Param {
                         name: "CPU".to_string(),
-                        value: sys_info.cpu_usage,
+                        value: sys_info.cpu_usage_str(),
                     },
                     Param {
                         name: "Memory".to_string(),
-                        value: sys_info.memory_usage,
+                        value: sys_info.memory_usage_str(),
                     },
                     Param {
                         name: "ProcessorTime".to_string(),
-                        value: sys_info.processor_time,
+                        value: sys_info.uptime_seconds_str(),
                     },
                 ]);
             },
@@ -690,8 +608,7 @@ async fn send_health_report(client: &Client, goal_state: &GoalState) -> Result<(
 }
 
 async fn send_status_report(client: &Client, goal_state: &GoalState) -> Result<()> {
-    let sys_info = get_system_info();
-    
+    let sys_info = SystemInfo::current();
     let status_content = serde_json::json!({
         "version": "1.1",
         "timestampUTC": get_rfc3339_timestamp(),
@@ -729,8 +646,8 @@ async fn send_status_report(client: &Client, goal_state: &GoalState) -> Result<(
         },
         "guestOSInfo": {
             "computerName": sys_info.hostname,
-            "osName": get_os_display_name(),
-            "osVersion": get_os_version(&sys_info),
+            "osName": sys_info.os_name,
+            "osVersion": sys_info.os_version,
             "version": AGENT_VERSION
         },
         "supportedFeatures": [


### PR DESCRIPTION
For some weird reason I choose a library that is not up to date and this created issues with multiple distros as defined in waagent-rs/waagent-rs#19.

This changes do two things:
- it updates the waagent-core (library or crate) to stop using os_info and sys_info, and use sysinfo instead. All test pass and code works well enough. It still needs some rigurous testing on multiple distributions, but for the main ones I tested it now prints the same messages as python waagent for the distro version
- It removes the duplicated code from POC which is now using the library. This will allow to move the code to the core and to eventually stop using poc in packaging