### PR TITLE
{Feature} Parse the waagent config file #5

### DIFF
--- a/waagent-core/Cargo.toml
+++ b/waagent-core/Cargo.toml
@@ -11,6 +11,7 @@ authors = [
     "Arun Kumar <arukum@microsoft.com>",
     "Esteban Flores <esflores@microsoft.com>",
     "Francisco Ortiz <frortizl@microsoft.com>",
+    "Greg Diaz <gregdiaz@microsoft.com>",
     "Jonathan Brenes <jbrenes@microsoft.com>",
     "Manish Kumawat <mkumawat@microsoft.com>",
     "Mitchelle Tenorio Quesada <mitenori@microsoft.com>",

--- a/waagent-core/src/config/defaults.rs
+++ b/waagent-core/src/config/defaults.rs
@@ -1,0 +1,125 @@
+use super::{Config, ConfigValue, HashMap};
+
+macro_rules! load_defaults_hashmap {
+    ($hashmap:ident, {
+        BOOL_OPTIONS: {$($bool_key:literal => $bool_value:expr),* $(,)?},
+        STRING_OPTIONS: {$($str_key:literal => $str_value:expr),* $(,)?},
+        INTEGER_OPTIONS: {$($int_key:literal => $int_value:expr),* $(,)?},
+        PORT_OPTIONS: {$($port_key:literal => $port_value:expr),* $(,)?}
+    }) => {
+        $($hashmap.insert($bool_key.to_string(), ConfigValue::Bool($bool_value));)*
+        $($hashmap.insert($str_key.to_string(), ConfigValue::String($str_value.to_string()));)*
+        $($hashmap.insert($int_key.to_string(), ConfigValue::Integer($int_value));)*
+        $($hashmap.insert($port_key.to_string(), ConfigValue::Port($port_value));)*
+    };
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            config: get_config_defaults(),
+        }
+    }
+}
+
+#[rustfmt::skip]
+pub fn get_config_defaults() -> HashMap<String,ConfigValue> {
+    let mut defaults = HashMap::new();
+    let quota = 30 * (1024_u32.pow(2));
+
+    load_defaults_hashmap!(defaults, {
+        BOOL_OPTIONS: {
+            "OS.AllowHTTP" => false,
+            "OS.EnableFirewall" => false,
+            "OS.EnableFIPS" => false,
+            "OS.EnableRDMA" => false,
+            "OS.UpdateRdmaDriver" => false,
+            "OS.CheckRdmaDriver" => false,
+            "Logs.Verbose" => false,
+            "Logs.Console" => true,
+            "Logs.Collect" => true,
+            "Extensions.Enabled" => true,
+            "Extensions.WaitForCloudInit" => false,
+            "Provisioning.AllowResetSysUser" => false,
+            "Provisioning.RegenerateSshHostKeyPair" => false,
+            "Provisioning.DeleteRootPassword" => false,
+            "Provisioning.DecodeCustomData" => false,
+            "Provisioning.ExecuteCustomData" => false,
+            "Provisioning.MonitorHostName" => false,
+            "DetectScvmmEnv" => false,
+            "ResourceDisk.Format" => false,
+            "ResourceDisk.EnableSwap" => false,
+            "ResourceDisk.EnableSwapEncryption" => false,
+            "AutoUpdate.Enabled" => true,
+            "AutoUpdate.UpdateToLatestVersion" => true,
+            "EnableOverProvisioning" => true,
+            //
+            // "Debug" options are experimental and may be removed in later
+            // versions of the Agent.
+            //
+            "Debug.CgroupLogMetrics" => false,
+            "Debug.CgroupDisableOnProcessCheckFailure" => true,
+            "Debug.CgroupDisableOnQuotaCheckFailure" => true,
+            "Debug.EnableAgentMemoryUsageCheck" => false,
+            "Debug.EnableFastTrack" => true,
+            "Debug.EnableGAVersioning" => true,
+            "Debug.EnableCgroupV2ResourceLimiting" => false,
+            "Debug.EnableExtensionPolicy" => false
+        },
+        STRING_OPTIONS: {
+            "Lib.Dir" => "/var/lib/waagent",
+            "DVD.MountPoint" => "/mnt/cdrom/secure",
+            "Pid.File" => "/var/run/waagent.pid",
+            "Extension.LogDir" => "/var/log/azure",
+            "OS.OpensslPath" => "/usr/bin/openssl",
+            "OS.SshDir" => "/etc/ssh",
+            "OS.HomeDir" => "/home",
+            "OS.PasswordPath" => "/etc/shadow",
+            "OS.SudoersDir" => "/etc/sudoers.d",
+            "OS.RootDeviceScsiTimeout" => "None",
+            "Provisioning.Agent" => "auto",
+            "Provisioning.SshHostKeyPairType" => "rsa",
+            "Provisioning.PasswordCryptId" => "6",
+            "HttpProxy.Host" => "None",
+            "ResourceDisk.MountPoint" => "/mnt/resource",
+            "ResourceDisk.MountOptions" => "None",
+            "ResourceDisk.Filesystem" => "ext3",
+            "AutoUpdate.GAFamily" => "Prod",
+            "Policy.PolicyFilePath" => "/etc/waagent_policy.json",
+            "Protocol.EndpointDiscovery" => "dhcp"
+        },
+        INTEGER_OPTIONS: {
+            "Extensions.GoalStatePeriod" => 6,
+            "Extensions.InitialGoalStatePeriod" => 6,
+            "Extensions.WaitForCloudInitTimeout" => 3600,
+            "OS.EnableFirewallPeriod" => 300,
+            "OS.RemovePersistentNetRulesPeriod" => 30,
+            "OS.RootDeviceScsiTimeoutPeriod" => 30,
+            "OS.MonitorDhcpClientRestartPeriod" => 30,
+            "OS.SshClientAliveInterval" => 180,
+            "Provisioning.MonitorHostNamePeriod" => 30,
+            "Provisioning.PasswordCryptSaltLength" => 10,
+            "ResourceDisk.SwapSizeMB" => 0,
+            "Autoupdate.Frequency" => 3600,
+            "Logs.CollectPeriod" => 3600,
+            //
+            //  "Debug" options are experimental and may be removed in later
+            //  versions of the Agent.
+            //
+            "Debug.CgroupCheckPeriod" => 300,
+            "Debug.AgentCpuQuota" => 50,
+            "Debug.AgentCpuThrottledTimeThreshold" => 120,
+            "Debug.AgentMemoryQuota" => quota, // 30 MiB is the max memory config can take https://github.com/Azure/WALinuxAgent/issues/2931
+            "Debug.EtpCollectionPeriod" => 300,
+            "Debug.AutoUpdateHotfixFrequency" => 14400,
+            "Debug.AutoUpdateNormalFrequency" => 86400,
+            "Debug.FirewallRulesLogPeriod" => 86400,
+            "Debug.LogCollectorInitialDelay" => 5 * 60
+        },
+        PORT_OPTIONS: {
+            "HttpProxy.Port" => None,
+        }
+    });
+
+    defaults
+}

--- a/waagent-core/src/config/mod.rs
+++ b/waagent-core/src/config/mod.rs
@@ -1,0 +1,9 @@
+mod defaults;
+mod parser;
+mod schema;
+mod show;
+mod types;
+
+pub use schema::ConfigSchema;
+pub use std::collections::HashMap;
+pub use types::{Config, ConfigValue, ExpectedType};

--- a/waagent-core/src/config/parser.rs
+++ b/waagent-core/src/config/parser.rs
@@ -1,0 +1,308 @@
+use super::{Config, ConfigSchema, ConfigValue, ExpectedType, HashMap};
+use crate::utils::fileutils::read_file;
+use std::path::Path;
+
+impl Config {
+    pub fn from_file(path: &Path) -> std::io::Result<Self> {
+        // This will return Err if read_file returns Err, which would be due to open()
+        // https://doc.rust-lang.org/stable/std/fs/struct.OpenOptions.html#method.open
+        // will also fail if the data in this stream is not valid UTF-8 then an error is returned and buf is unchanged
+        // caller will need to handle errors.
+        let data: String = read_file(path)?;
+        let parsed_data = Self::parse(&data);
+
+        Ok(Self {
+            config: Self::merge_with_defaults(parsed_data),
+        })
+    }
+
+    fn parse(data: &str) -> HashMap<String, ConfigValue> {
+        let mut values = HashMap::new();
+        let schema = ConfigSchema::new();
+        let defaults = Config::default();
+
+        for line in data.lines() {
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+
+            let (key, value) = match split_key_value(line) {
+                Some(pair) => pair,
+                None => continue,
+            };
+
+            if !schema.is_valid_key(&key) {
+                continue;
+            }
+
+            let expected_type = schema.get_expected_type(&key);
+            let config_value = parse_config_value(&key, &value, expected_type, &defaults);
+
+            if let Some(config_value) = config_value {
+                values.insert(key.to_string(), config_value);
+            }
+        }
+
+        values
+    }
+}
+
+fn split_key_value(line: &str) -> Option<(String, String)> {
+    // filter in-line comments
+    let line = line.split('#').next()?.trim();
+
+    let mut parts = line.splitn(2, '=');
+    let key = parts.next()?.trim();
+    if key.is_empty() {
+        return None;
+    }
+    let value = parts.next().unwrap_or("").trim();
+
+    Some((key.to_string(), value.to_string()))
+}
+
+fn parse_config_value(
+    key: &str,
+    value: &str,
+    expected_type: Option<&ExpectedType>,
+    defaults: &Config,
+) -> Option<ConfigValue> {
+    match key {
+        "HttpProxy.Port" => {
+            parse_port_value(&value).or_else(|| fallback_to_default(&key, &defaults))
+        }
+        _ if expected_type == Some(&ExpectedType::Bool) => {
+            parse_bool_value(&value).or_else(|| fallback_to_default(&key, &defaults))
+        }
+        _ if expected_type == Some(&ExpectedType::String) => {
+            parse_string_value(&value).or_else(|| fallback_to_default(&key, &defaults))
+        }
+        _ if expected_type == Some(&ExpectedType::Integer) => {
+            parse_integer_value(&value).or_else(|| fallback_to_default(&key, &defaults))
+        }
+        _ => None,
+    }
+}
+
+fn parse_bool_value(value: &str) -> Option<ConfigValue> {
+    match value {
+        "y" | "Y" => Some(ConfigValue::Bool(true)),
+        "n" | "N" => Some(ConfigValue::Bool(false)),
+        _ => None,
+    }
+}
+
+fn parse_string_value(value: &str) -> Option<ConfigValue> {
+    match value {
+        "\"\"" => Some(ConfigValue::String(String::from("None"))),
+        v if !v.is_empty() => Some(ConfigValue::String(v.to_string())),
+        _ => None,
+    }
+}
+
+fn parse_integer_value(value: &str) -> Option<ConfigValue> {
+    value.parse::<u32>().ok().map(ConfigValue::Integer)
+}
+
+fn parse_port_value(value: &str) -> Option<ConfigValue> {
+    if value == "None" || value.is_empty() {
+        Some(ConfigValue::Port(None))
+    } else {
+        match value.parse::<u16>() {
+            Ok(port) => Some(ConfigValue::Port(Some(port))),
+            _ => None,
+        }
+    }
+}
+
+fn fallback_to_default(key: &str, defaults: &Config) -> Option<ConfigValue> {
+    defaults.get_value(key).cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::types::{Config, ConfigValue};
+    #[test]
+    fn test_parse_bool() {
+        let input = "Extensions.Enabled=y";
+        let parsed_input = Config::parse(input);
+
+        assert_eq!(
+            parsed_input.get("Extensions.Enabled"),
+            Some(&ConfigValue::Bool(true))
+        )
+    }
+
+    #[test]
+    fn test_parse_invalid_bool() {
+        let input = "Extensions.Enabled=maybe";
+        let parsed = Config::parse(input);
+
+        let default = Config::default();
+        let expected = default.get_value("Extensions.Enabled");
+
+        assert_eq!(parsed.get("Extensions.Enabled"), expected);
+    }
+
+    #[test]
+    fn test_parse_int() {
+        let input = "OS.SshClientAliveInterval=6";
+        let parsed_input = Config::parse(input);
+
+        assert_eq!(
+            parsed_input.get("OS.SshClientAliveInterval"),
+            Some(&ConfigValue::Integer(6))
+        )
+    }
+
+    #[test]
+    fn test_parse_str() {
+        let input = "ResourceDisk.MountPoint=/mnt/resource";
+        let parsed_input = Config::parse(input);
+
+        assert_eq!(
+            parsed_input.get("ResourceDisk.MountPoint"),
+            Some(&ConfigValue::String(String::from("/mnt/resource")))
+        )
+    }
+
+    #[test]
+    fn test_parse_mixed() {
+        let input = "# Allow fallback to HTTP if HTTPS is unavailable\n# Note: Allowing HTTP (vs. HTTPS) may cause security risks\n# OS.AllowHTTP=n\n\n# Add firewall rules to protect access to Azure host node services\nOS.EnableFirewall=n\n\n# How often (in seconds) to check the firewall rules";
+        let parsed_input = Config::parse(input);
+
+        assert_eq!(
+            parsed_input.get("OS.EnableFirewall"),
+            Some(&ConfigValue::Bool(false))
+        )
+    }
+
+    #[test]
+    fn test_parse_with_whitespace() {
+        let input = "\r\n                 Provisioning.ExecuteCustomData = n       \t";
+        let parsed_input = Config::parse(input);
+
+        assert_eq!(
+            parsed_input.get("Provisioning.ExecuteCustomData"),
+            Some(&ConfigValue::Bool(false))
+        )
+    }
+
+    #[test]
+    fn test_ignores_empty() {
+        let input = "\n";
+        let parsed_input = Config::parse(input);
+
+        assert_eq!(parsed_input.len(), 0);
+    }
+
+    #[test]
+    fn test_ignores_comments() {
+        let input = "# If set, agent will use proxy server to access internet";
+        let parsed_input = Config::parse(input);
+
+        assert_eq!(parsed_input.len(), 0);
+        assert!(parsed_input.is_empty(), "Should ignore comments")
+    }
+
+    #[test]
+    fn test_edge_parse_missing_key() {
+        let input = "=y";
+        let parsed_input = Config::parse(input);
+
+        assert_eq!(parsed_input.len(), 0);
+    }
+
+    #[test]
+    fn test_edge_parse_missing_value() {
+        let input = "ResourceDisk.SwapSizeMB=";
+        let parsed_input = Config::parse(input);
+
+        assert_eq!(parsed_input.len(), 1);
+        assert_eq!(
+            parsed_input.get("ResourceDisk.SwapSizeMB"),
+            Some(&ConfigValue::Integer(0))
+        );
+    }
+
+    #[test]
+    fn test_edge_parse_missing_key_value() {
+        let input = " = ";
+        let parsed_input = Config::parse(input);
+
+        assert_eq!(parsed_input.len(), 0);
+    }
+
+    #[test]
+    fn test_edge_parse_multi_value() {
+        let input = "ResourceDisk.SwapSizeMB=0,200,30";
+        let parsed_input = Config::parse(input);
+
+        assert_eq!(parsed_input.len(), 1);
+        assert_eq!(
+            parsed_input.get("ResourceDisk.SwapSizeMB"),
+            Some(&ConfigValue::Integer(0))
+        );
+    }
+
+    #[test]
+    fn test_edge_parse_invalid_key_only() {
+        let input = "Fake.key";
+        let parsed_input = Config::parse(input);
+
+        assert_eq!(parsed_input.len(), 0);
+    }
+
+    #[test]
+    fn test_edge_parse_valid_key_only() {
+        let input = "Lib.Dir";
+        let parsed_input = Config::parse(input);
+
+        assert_eq!(parsed_input.len(), 1);
+        assert_eq!(
+            parsed_input.get("Lib.Dir"),
+            Some(&ConfigValue::String("/var/lib/waagent".to_string()))
+        )
+    }
+
+    #[test]
+    fn test_edge_parse_multiple_equals_signs() {
+        let input = "Provisioning.Agent=auto=default";
+        let parsed = Config::parse(input);
+
+        assert_eq!(
+            parsed.get("Provisioning.Agent"),
+            Some(&ConfigValue::String(String::from("auto=default")))
+        );
+    }
+
+    #[test]
+    fn test_edge_parse_duplicate_keys_last_wins() {
+        let input = "Logs.Verbose=n\nLogs.Verbose=y";
+        let parsed = Config::parse(input);
+
+        assert_eq!(parsed.get("Logs.Verbose"), Some(&ConfigValue::Bool(true)));
+    }
+
+    #[test]
+    fn test_edge_parse_inline_comment_in_value() {
+        let input = "OS.EnableFirewall=y # turn on firewall";
+        let parsed = Config::parse(input);
+
+        assert_eq!(
+            parsed.get("OS.EnableFirewall"),
+            Some(&ConfigValue::Bool(true))
+        );
+    }
+
+    #[test]
+    fn test_edge_parse_utf8_string_value() {
+        let input = "Provisioning.Agent=μcloud-init";
+        let parsed = Config::parse(input);
+
+        assert_eq!(
+            parsed.get("Provisioning.Agent"),
+            Some(&ConfigValue::String("μcloud-init".to_string()))
+        );
+    }
+}

--- a/waagent-core/src/config/schema.rs
+++ b/waagent-core/src/config/schema.rs
@@ -1,0 +1,144 @@
+use super::{ExpectedType, HashMap};
+
+macro_rules! load_schema_hashmap {
+    ($hashmap:ident, {
+        BOOL_TYPES: {$($bool_key:literal),* $(,)?},
+        STRING_TYPES: {$($str_key:literal),* $(,)?},
+        INTEGER_TYPES: {$($int_key:literal),* $(,)?},
+        PORT_TYPES: {$($port_key:literal),* $(,)?}
+    }) => {
+        $($hashmap.insert($bool_key.to_string(), ExpectedType::Bool);)*
+        $($hashmap.insert($str_key.to_string(), ExpectedType::String);)*
+        $($hashmap.insert($int_key.to_string(), ExpectedType::Integer);)*
+        $($hashmap.insert($port_key.to_string(), ExpectedType::Port);)*
+    };
+}
+
+pub struct ConfigSchema {
+    schema: HashMap<String, ExpectedType>,
+}
+
+impl ConfigSchema {
+    pub fn new() -> Self {
+        Self {
+            schema: get_config_schema(),
+        }
+    }
+
+    pub fn schema(&self) -> &HashMap<String, ExpectedType> {
+        &self.schema
+    }
+
+    pub fn get_expected_type(&self, key: &str) -> Option<&ExpectedType> {
+        self.schema.get(key)
+    }
+
+    pub fn is_valid_key(&self, key: &str) -> bool {
+        self.schema.contains_key(key)
+    }
+
+    pub fn expected_types(&self) -> std::collections::hash_map::Values<'_, String, ExpectedType> {
+        self.schema.values()
+    }
+}
+
+#[rustfmt::skip]
+fn get_config_schema() -> HashMap<String, ExpectedType> {
+    let mut schema = HashMap::new();
+    load_schema_hashmap! (schema, {
+        BOOL_TYPES: {
+            "OS.AllowHTTP",
+            "OS.EnableFirewall",
+            "OS.EnableFIPS",
+            "OS.EnableRDMA",
+            "OS.UpdateRdmaDriver",
+            "OS.CheckRdmaDriver",
+            "Logs.Verbose",
+            "Logs.Console",
+            "Logs.Collect",
+            "Extensions.Enabled",
+            "Extensions.WaitForCloudInit",
+            "Provisioning.AllowResetSysUser",
+            "Provisioning.RegenerateSshHostKeyPair",
+            "Provisioning.DeleteRootPassword",
+            "Provisioning.DecodeCustomData",
+            "Provisioning.ExecuteCustomData",
+            "Provisioning.MonitorHostName",
+            "DetectScvmmEnv",
+            "ResourceDisk.Format",
+            "ResourceDisk.EnableSwap",
+            "ResourceDisk.EnableSwapEncryption",
+            "AutoUpdate.Enabled",
+            "AutoUpdate.UpdateToLatestVersion",
+            "EnableOverProvisioning",
+            //
+            // "Debug" options are experimental and may be removed in later
+            // versions of the Agent.
+            //
+            "Debug.CgroupLogMetrics",
+            "Debug.CgroupDisableOnProcessCheckFailure",
+            "Debug.CgroupDisableOnQuotaCheckFailure",
+            "Debug.EnableAgentMemoryUsageCheck",
+            "Debug.EnableFastTrack",
+            "Debug.EnableGAVersioning",
+            "Debug.EnableCgroupV2ResourceLimiting",
+            "Debug.EnableExtensionPolicy",
+        },
+        STRING_TYPES: {
+            "Lib.Dir",
+            "DVD.MountPoint",
+            "Pid.File",
+            "Extension.LogDir",
+            "OS.OpensslPath",
+            "OS.SshDir",
+            "OS.HomeDir",
+            "OS.PasswordPath",
+            "OS.SudoersDir",
+            "OS.RootDeviceScsiTimeout",
+            "Provisioning.Agent",
+            "Provisioning.SshHostKeyPairType",
+            "Provisioning.PasswordCryptId",
+            "HttpProxy.Host",
+            "ResourceDisk.MountPoint",
+            "ResourceDisk.MountOptions",
+            "ResourceDisk.Filesystem",
+            "AutoUpdate.GAFamily",
+            "Policy.PolicyFilePath",
+            "Protocol.EndpointDiscovery",
+        },
+        INTEGER_TYPES: {
+            "Extensions.GoalStatePeriod",
+            "Extensions.InitialGoalStatePeriod",
+            "Extensions.WaitForCloudInitTimeout",
+            "OS.EnableFirewallPeriod",
+            "OS.RemovePersistentNetRulesPeriod",
+            "OS.RootDeviceScsiTimeoutPeriod",
+            "OS.MonitorDhcpClientRestartPeriod",
+            "OS.SshClientAliveInterval",
+            "Provisioning.MonitorHostNamePeriod",
+            "Provisioning.PasswordCryptSaltLength",
+            "ResourceDisk.SwapSizeMB",
+            "Autoupdate.Frequency",
+            "Logs.CollectPeriod",
+            //
+            //  "Debug" options are experimental and may be removed in later
+            //  versions of the Agent.
+            //
+            "Debug.CgroupCheckPeriod",
+            "Debug.AgentCpuQuota",
+            "Debug.AgentCpuThrottledTimeThreshold",
+            "Debug.AgentMemoryQuota",
+            "Debug.EtpCollectionPeriod",
+            "Debug.AutoUpdateHotfixFrequency",
+            "Debug.AutoUpdateNormalFrequency",
+            "Debug.FirewallRulesLogPeriod",
+            "Debug.LogCollectorInitialDelay",
+        },
+        PORT_TYPES: {
+            "HttpProxy.Port",
+
+        }
+        });
+
+    schema
+}

--- a/waagent-core/src/config/show.rs
+++ b/waagent-core/src/config/show.rs
@@ -1,0 +1,55 @@
+use super::{Config, ConfigValue};
+use std::collections::BTreeMap;
+
+impl Config {
+    pub fn show(self) -> String {
+        let merged = Self::merge_with_defaults(self.config().clone());
+        let sorted: BTreeMap<_, _> = merged.into_iter().collect();
+        let mut output = String::new();
+
+        for (key, v) in sorted {
+            let value = match v {
+                ConfigValue::Bool(bool) => bool.to_string(),
+                ConfigValue::Integer(int) => int.to_string(),
+                ConfigValue::String(string) => string.clone(),
+                ConfigValue::Port(Some(port)) => port.to_string(),
+                ConfigValue::Port(None) => "None".to_string(),
+            };
+            output.push_str(&format!("{} = {}\n", key, value));
+        }
+
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, ConfigValue};
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_show_merges_defaults() {
+        let mut user_config = HashMap::new();
+        user_config.insert("OS.AllowHTTP".to_string(), ConfigValue::Bool(true));
+
+        let config = Config::from_map(user_config);
+        let output = config.show();
+
+        // a value provided by user
+        assert!(output.contains("OS.AllowHTTP = true"));
+        // a default value
+        assert!(output.contains("OS.EnableFirewall = false"));
+    }
+
+    #[test]
+    fn test_show_is_sorted() {
+        let config = Config::default();
+        let output = config.show();
+        let lines: Vec<&str> = output.lines().collect();
+
+        // Check sort
+        let mut sorted = lines.clone();
+        sorted.sort();
+        assert_eq!(lines, sorted);
+    }
+}

--- a/waagent-core/src/config/types.rs
+++ b/waagent-core/src/config/types.rs
@@ -1,0 +1,48 @@
+use super::HashMap;
+use crate::config::defaults::get_config_defaults;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConfigValue {
+    Bool(bool),
+    String(String),
+    Integer(u32), // config values shouldn't be negative and probably not greater then
+    Port(Option<u16>), //u16 becuase ports 2^16 = 0-65535
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ExpectedType {
+    Bool,
+    Integer,
+    String,
+    Port,
+}
+
+pub struct Config {
+    pub config: HashMap<String, ConfigValue>,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn config(&self) -> &HashMap<String, ConfigValue> {
+        &self.config
+    }
+
+    pub fn get_value(&self, key: &str) -> Option<&ConfigValue> {
+        self.config.get(key)
+    }
+
+    pub fn from_map(hashmap: HashMap<String, ConfigValue>) -> Self {
+        Self { config: hashmap }
+    }
+
+    #[rustfmt::skip]
+    pub fn merge_with_defaults(hashmap: HashMap<String, ConfigValue>) -> HashMap<String, ConfigValue> {
+        let mut merged = get_config_defaults();
+        merged.extend(hashmap);
+
+        merged
+    }
+}

--- a/waagent-core/src/lib.rs
+++ b/waagent-core/src/lib.rs
@@ -1,2 +1,4 @@
-pub mod system;
+pub mod config;
 pub mod network;
+pub mod system;
+pub mod utils;

--- a/waagent-core/src/utils/fileutils.rs
+++ b/waagent-core/src/utils/fileutils.rs
@@ -1,0 +1,13 @@
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::Path;
+
+pub fn read_file(path: &Path) -> std::io::Result<String> {
+    // Errors should be propagated since this is a lib, caller in waagent-rs should handle errors.
+    // https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html#propagating-errors
+    let mut file = File::open(path)?;
+    let mut buffer = String::new();
+
+    file.read_to_string(&mut buffer)?;
+    Ok(buffer)
+}

--- a/waagent-core/src/utils/mod.rs
+++ b/waagent-core/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod fileutils;

--- a/waagent-core/tests/config/config_tests.rs
+++ b/waagent-core/tests/config/config_tests.rs
@@ -1,0 +1,100 @@
+use std::path::Path;
+use waagent_core::config::{Config, ConfigSchema, ConfigValue, ExpectedType};
+
+#[test]
+fn test_default_config_has_all_required_keys() {
+    let default_config = Config::default();
+    let schema_config = ConfigSchema::new();
+    assert!(schema_config
+        .schema()
+        .keys()
+        .all(|k| default_config.config().contains_key(k)));
+}
+
+#[test]
+fn test_default_config_matches_schema_types() {
+    let default_config = Config::default();
+    let schema_config = ConfigSchema::new();
+
+    for (key, value) in schema_config.schema() {
+        let default_value = match default_config.get_value(key) {
+            Some(&ConfigValue::Bool(_)) => &ExpectedType::Bool,
+            Some(&ConfigValue::String(_)) => &ExpectedType::String,
+            Some(&ConfigValue::Integer(_)) => &ExpectedType::Integer,
+            Some(&ConfigValue::Port(_)) => &ExpectedType::Port,
+            None => panic!("Missing default config value for key: {}", key),
+        };
+        assert_eq!(
+            value, default_value,
+            "Type mismatch for key: {}. Expected: {:?}, Got: {:?}",
+            key, value, default_value
+        );
+    }
+}
+
+#[test]
+fn test_show_config_output_from_file() {
+    let test_config_path: &Path = Path::new("tests/config/data/waagent-test.conf");
+    let config = Config::from_file(test_config_path);
+    let output = config
+        .expect(&format!("Missing file at {:?}", test_config_path))
+        .show();
+
+    let schema = ConfigSchema::new();
+    let schema_count = schema.schema().keys().count();
+    let output_count = output.lines().count();
+
+    assert!(output.contains("Extensions.Enabled = true"));
+    assert!(output.contains("Provisioning.Agent = auto"));
+    assert!(output.contains("Extension.LogDir = /var/log/azure"));
+    assert!(!output.contains("FauxKey1 = Value1"));
+    assert!(!output.contains("key = value"));
+    assert!(!output.contains("ResourceDisk.MountPoint = /mnt/resource"));
+    assert_eq!(schema_count, output_count);
+}
+
+#[test]
+#[rustfmt::skip]
+fn test_config_file_example() {
+    let test_config_path: &Path = Path::new("tests/config/data/waagent-test.conf");
+    let config = Config::from_file(test_config_path).expect(&format!("Missing file at {:?}",  test_config_path));
+    
+    assert_ne!(config.get_value(""), Some(&(ConfigValue::String("Value0".to_string()))));
+    assert_ne!(config.get_value("FauxKey1"), Some(&ConfigValue::String("Value1".to_string())));
+    assert_ne!(config.get_value("FauxKey2"), Some(&ConfigValue::String("Value2 Value2".to_string())));
+    assert_ne!(config.get_value("FauxKey3"), Some(&ConfigValue::String("delalloc,rw,noatime,nobarrier,users,mode=777".to_string())));
+    assert_ne!(config.get_value(""), Some(&ConfigValue::String("".to_string())));
+    assert_ne!(config.get_value("key"), Some(&ConfigValue::String("value".to_string())));
+
+    assert_eq!(config.get_value("Extensions.Enabled"), Some(&ConfigValue::Bool(true)));
+    assert_eq!(config.get_value("Provisioning.Agent"), Some(&ConfigValue::String("auto".to_string())));
+    assert_eq!(config.get_value("Provisioning.DeleteRootPassword"), Some(&ConfigValue::Bool(true)));
+    assert_eq!(config.get_value("Provisioning.RegenerateSshHostKeyPair"), Some(&ConfigValue::Bool(true)));
+    assert_eq!(config.get_value("Provisioning.SshHostKeyPairType"), Some(&ConfigValue::String("rsa".to_string())));
+    assert_eq!(config.get_value("Provisioning.MonitorHostName"), Some(&ConfigValue::Bool(true)));
+    assert_eq!(config.get_value("Provisioning.DecodeCustomData"), Some(&ConfigValue::Bool(false)));
+    assert_eq!(config.get_value("Provisioning.ExecuteCustomData"), Some(&ConfigValue::Bool(false)));
+    assert_eq!(config.get_value("Provisioning.AllowResetSysUser"), Some(&ConfigValue::Bool(false)));
+    assert_eq!(config.get_value("ResourceDisk.Format"), Some(&ConfigValue::Bool(true)));
+    assert_eq!(config.get_value("ResourceDisk.Filesystem"), Some(&ConfigValue::String("ext4".to_string())));
+    assert_eq!(config.get_value("ResourceDisk.MountPoint"), Some(&ConfigValue::String("/mnt".to_string())));
+    assert_eq!(config.get_value("ResourceDisk.EnableSwap"), Some(&ConfigValue::Bool(false)));
+    assert_eq!(config.get_value("ResourceDisk.EnableSwapEncryption"), Some(&ConfigValue::Bool(false)));
+    assert_eq!(config.get_value("ResourceDisk.SwapSizeMB"), Some(&ConfigValue::Integer(0)));
+    assert_eq!(config.get_value("ResourceDisk.MountOptions"), Some(&ConfigValue::String("None".to_string())));
+    assert_eq!(config.get_value("Logs.Verbose"), Some(&ConfigValue::Bool(false)));
+    assert_eq!(config.get_value("Logs.Collect"), Some(&ConfigValue::Bool(true)));
+    assert_eq!(config.get_value("Logs.CollectPeriod"), Some(&ConfigValue::Integer(3600)));
+    assert_eq!(config.get_value("OS.EnableFIPS"), Some(&ConfigValue::Bool(true)));
+    assert_eq!(config.get_value("OS.RootDeviceScsiTimeout"), Some(&ConfigValue::String("300".to_string())));
+    assert_eq!(config.get_value("OS.OpensslPath"), Some(&ConfigValue::String("None".to_string())));
+    assert_eq!(config.get_value("OS.SshClientAliveInterval"), Some(&ConfigValue::Integer(42)));
+    assert_eq!(config.get_value("OS.SshDir"), Some(&ConfigValue::String("/notareal/path".to_string())));
+    assert_eq!(config.get_value("OS.EnableFirewall"), Some(&ConfigValue::Bool(false)));
+    assert_eq!(config.get_value("Debug.EnableExtensionPolicy"), Some(&ConfigValue::Bool(false)));
+
+    // check defaults merged
+    assert_eq!(config.get_value("Lib.Dir"), Some(&ConfigValue::String("/var/lib/waagent".to_string())));
+    assert_eq!(config.get_value("DetectScvmmEnv"), Some(&ConfigValue::Bool(false)));
+    assert_eq!(config.get_value("OS.HomeDir"), Some(&ConfigValue::String("/home".to_string())));
+}

--- a/waagent-core/tests/config/data/waagent-test.conf
+++ b/waagent-core/tests/config/data/waagent-test.conf
@@ -1,0 +1,157 @@
+#
+# Microsoft Azure Linux Agent Configuration
+#
+
+# Key / value handling test entries
+=Value0
+FauxKey1= Value1
+FauxKey2=Value2 Value2
+FauxKey3=delalloc,rw,noatime,nobarrier,users,mode=777
+ = 
+ key=value # inline-comment
+
+# invalid switches, with valid keys should only accept y | Y || n | N
+Extensions.Enabled=yes
+Provisioning.DeleteRootPassword=true
+Provisioning.MonitorHostName=YES
+Provisioning.ExecuteCustomData=FALSE
+Provisioning.AllowResetSysUser=No
+Provisioning.AllowResetSysUser=false
+ResourceDisk.Format=On
+ResourceDisk.EnableSwap=off
+
+# Enable extension handling
+Extensions.Enabled=y
+
+# Specify provisioning agent.
+Provisioning.Agent=auto
+
+# Password authentication for root account will be unavailable.
+Provisioning.DeleteRootPassword=y
+
+# Generate fresh host key pair.
+Provisioning.RegenerateSshHostKeyPair=Y # test captital Y and inline comment
+
+# Supported values are "rsa", "dsa", "ecdsa", "ed25519", and "auto".
+# The "auto" option is supported on OpenSSH 5.9 (2011) and later.
+Provisioning.SshHostKeyPairType=rsa # An EOL comment that should be ignored
+
+# Monitor host name changes and publish changes via DHCP requests.
+Provisioning.MonitorHostName=y
+
+# Decode CustomData from Base64.
+Provisioning.DecodeCustomData=n#Another EOL comment that should be ignored
+
+# Execute CustomData after provisioning.
+Provisioning.ExecuteCustomData = N    # Test captital "N" and inline comment with tabs and whitespace
+
+# Algorithm used by crypt when generating password hash.
+#Provisioning.PasswordCryptId=6
+
+# Length of random salt used when generating password hash.
+#Provisioning.PasswordCryptSaltLength=10
+
+# Allow reset password of sys user
+Provisioning.AllowResetSysUser=n
+
+# Format if unformatted. If 'n', resource disk will not be mounted.
+ResourceDisk.Format=y
+
+# File system on the resource disk
+# Typically ext3 or ext4. FreeBSD images should use 'ufs2' here.
+ResourceDisk.Filesystem=ext4
+
+# Mount point for the resource disk
+ResourceDisk.MountPoint=/mnt/resource
+# Test duplicate override
+ResourceDisk.MountPoint=/mnt
+
+# Create and use swapfile on resource disk.
+ResourceDisk.EnableSwap=n
+
+# Use encrypted swap
+ResourceDisk.EnableSwapEncryption=n
+
+# Size of the swapfile.
+ResourceDisk.SwapSizeMB=0
+
+# Comma-seperated list of mount options. See man(8) for valid options.
+ResourceDisk.MountOptions=None
+
+# Enable verbose logging (y|n)
+Logs.Verbose=n
+
+# Enable periodic log collection, default is y
+Logs.Collect=y
+
+# How frequently to collect logs, default is each hour
+Logs.CollectPeriod=3600
+
+# Is FIPS enabled
+OS.EnableFIPS=y#Another EOL comment that should be ignored
+
+# Root device timeout in seconds.
+OS.RootDeviceScsiTimeout=300
+
+# If "None", the system default version is used.
+OS.OpensslPath=None
+
+# Set the SSH ClientAliveInterval
+OS.SshClientAliveInterval=42#Yet another EOL comment with a '#' that should be ignored
+
+# Set the path to SSH keys and configuration files
+OS.SshDir=/notareal/path
+
+# If set, agent will use proxy server to access internet
+#HttpProxy.Host=None
+#HttpProxy.Port=None
+
+# Detect Scvmm environment, default is n
+# DetectScvmmEnv=n
+
+#
+# Lib.Dir=/var/lib/waagent
+
+#
+# DVD.MountPoint=/mnt/cdrom/secure
+
+#
+# Pid.File=/var/run/waagent.pid
+
+#
+# Extension.LogDir=/var/log/azure
+
+#
+# OS.HomeDir=/home
+
+# Enable RDMA management and set up, should only be used in HPC images
+# OS.EnableRDMA=n
+# OS.UpdateRdmaDriver=n
+# OS.CheckRdmaDriver=n
+
+
+# Enable or disable goal state processing auto-update, default is enabled.
+# Deprecated now but keep it for backward compatibility
+# AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# AutoUpdate.UpdateToLatestVersion=y
+
+# Determine the update family, this should not be changed
+# AutoUpdate.GAFamily=Prod
+
+# Determine if the overprovisioning feature is enabled. If yes, hold extension
+# handling until inVMArtifactsProfile.OnHold is false.
+# Default is enabled
+# EnableOverProvisioning=y
+
+# Allow fallback to HTTP if HTTPS is unavailable
+# Note: Allowing HTTP (vs. HTTPS) may cause security risks
+# OS.AllowHTTP=n
+
+# Add firewall rules to protect access to Azure host node services
+# Note:
+# - The default is false to protect the state of existing VMs
+OS.EnableFirewall=n
+
+Debug.EnableExtensionPolicy=n

--- a/waagent-core/tests/config/mod.rs
+++ b/waagent-core/tests/config/mod.rs
@@ -1,0 +1,1 @@
+mod config_tests;

--- a/waagent-core/tests/tests.rs
+++ b/waagent-core/tests/tests.rs
@@ -1,1 +1,2 @@
+mod config;
 mod system;


### PR DESCRIPTION
Feature Add #5
---

## ✨ Add `config` and `utils` crates to `waagent-core`

### Overview

This PR introduces two new modules to `waagent-core`:

* **`config`** → Provides configuration schema, defaults, parsing, and presentation.
* **`utils`** → Provides reusable utilities (currently `fileutils` for safe file reads).

These changes improve type safety, validation, and usability of agent configuration.

---

### 🔧 Changes

#### **New `config` crate**

* **Files added:**

  * `config/defaults.rs` → Defines default configuration values via a macro + `Config::default`.
  * `config/types.rs` → Defines `Config`, `ConfigValue`, and `ExpectedType`.
  * `config/schema.rs` → Defines `ConfigSchema` with expected types for each config key.
  * `config/parser.rs` → Provides parsing and merging utilities.
  * `config/show.rs` → Pretty-prints configuration in sorted key order.

* **Key features:**

  * Strongly typed config values: `Bool`, `String`, `Integer(u32)`, `Port(Option<u16>)`.
  * Defaults and schema are fully enumerated to prevent missing or mismatched keys.
  * Ability to merge user config with defaults.
  * `Config.show()` produces sorted, human-readable configuration output.

#### **New `utils` crate**

* **Files added:**

  * `utils/fileutils.rs` → Adds `read_file` helper with proper error propagation.
  * `utils/mod.rs`.

---

### ✅ Tests

* **Integration tests added under `tests/config/`:**

  * `config_tests.rs`
  * `data/waagent-test.conf` (sample config file)

* **Test coverage includes:**

  * Ensuring default config matches schema.
  * Type validation of defaults vs schema.
  * Merging user config with defaults.
  * Sorted + correct `show()` output.
  * Parsing a real config file (`waagent-test.conf`) with inline comments, overrides, and invalid entries.

---

### 📌 Example

Sample invocation (`Config::from_file`) will:

* Parse user config values.
* Merge them with defaults.
* Validate against schema.
* Produce output like:

```
Extensions.Enabled = true
OS.EnableFirewall = false
ResourceDisk.Filesystem = ext4
...
```

---

### 🧩 Next Steps

* Expand `utils` with additional helpers.
* Extend `config` parser for richer error reporting and stricter validation.
* Hook into `waagent-rs` runtime in a more robust way for actual agent configuration loading.

---