### PR TITLE
Adding dependabot updates weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Dependabot version updates
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
This improves the OpenSSF score. It causes a weekly dependabot update using Cargo, which will then create PRs to automate dependency updates.

Scorecard rule: DependencyUpdateToolID