### PR TITLE
Deprovision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,10 @@ tokio = { version = "1", features = ["signal", "process", "macros", "rt-multi-th
 
 sysinfo = "0.37"
 
+# Glob expansion (used by deprovision handler)
+glob = "0.3"
+
+# XML (used to parse ovf-env.xml)
+quick-xml = "0.38"
+
 winapi = { version = "0.3", features = ["sysinfoapi"] }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,37 @@ sudo systemctl start waagent-rs
 
 Wait a few seconds, and go and check the Agent Status of the VM in the portal.
 
+## Deprovisioning
+
+`waagent-rs` ports the deprovision behavior of the Python WALinuxAgent
+(`azurelinuxagent.pa.deprovision`). It cleans up VM-specific state
+(cached goal state, host keys, DHCP leases, hostname, agent log files,
+persisted firewall rules, cgroup drop-ins, …) so the disk can be
+captured as a generalized image.
+
+The CLI uses two separate flags instead of WALA's `+user` modifier:
+
+| Goal | WALinuxAgent | waagent-rs |
+| --- | --- | --- |
+| Deprovision (keep the user account) | `sudo waagent -deprovision` | `sudo waagent --deprovision` |
+| Deprovision and remove the provisioned user + home dir | `sudo waagent -deprovision+user` | `sudo waagent --deprovision --deprovision-user` |
+| Skip the interactive `y/n` prompt | `sudo waagent -deprovision -force` | `sudo waagent --deprovision --force` |
+
+Notes:
+
+- `--deprovision-user` and `--force` only make sense alongside
+  `--deprovision` and the CLI rejects them otherwise.
+- When `--deprovision-user` is set, the username is read from the cached
+  `/var/lib/waagent/ovf-env.xml`. If that file is missing, the
+  provisioning DVD (`/dev/sr0` or similar) is mounted read-only at
+  `/mnt/cdrom/secure` to read it; the mount is released afterwards.
+- Distro-specific behavior matches WALA: Ubuntu 18.04+ leaves
+  `/etc/resolv.conf` alone, older Ubuntu rewrites the resolvconf
+  fragments, and Arch / CoreOS / Flatcar additionally remove
+  `/etc/machine-id`.
+- The command must be run as root (or via `sudo`) because it stops
+  systemd units, runs `userdel`, locks the root password, and removes
+  files under `/etc`, `/var/lib`, and `/lib/systemd/system`.
 
 ## For Developers
 

--- a/waagent-core/Cargo.toml
+++ b/waagent-core/Cargo.toml
@@ -22,6 +22,8 @@ authors = [
 [dependencies]
 sysinfo = { workspace = true }
 tracing = { workspace = true }
+glob = { workspace = true }
+quick-xml = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { workspace = true }

--- a/waagent-core/src/deprovision/default.rs
+++ b/waagent-core/src/deprovision/default.rs
@@ -1,0 +1,21 @@
+//! Default (generic) deprovision handler — equivalent to
+//! `azurelinuxagent.pa.deprovision.default.DeprovisionHandler`.
+
+use super::DeprovisionHandler;
+
+/// Generic deprovision handler used when no distro-specific override applies.
+pub struct DefaultDeprovisionHandler;
+
+impl DefaultDeprovisionHandler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for DefaultDeprovisionHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeprovisionHandler for DefaultDeprovisionHandler {}

--- a/waagent-core/src/deprovision/distro.rs
+++ b/waagent-core/src/deprovision/distro.rs
@@ -1,0 +1,150 @@
+//! Distro-specific deprovision handlers (port of
+//! `azurelinuxagent/pa/deprovision/{ubuntu,arch,coreos,clearlinux}.py`).
+
+use std::path::Path;
+
+use super::{DeprovisionAction, DeprovisionEngine, DeprovisionHandler, DeprovisionPlan};
+use crate::config::Config;
+
+// ---------------------------------------------------------------------------
+// Ubuntu (pre-18.04): replace `del_resolv` with the resolvconf-aware variant.
+// ---------------------------------------------------------------------------
+pub struct UbuntuDeprovisionHandler;
+
+impl UbuntuDeprovisionHandler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for UbuntuDeprovisionHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeprovisionHandler for UbuntuDeprovisionHandler {
+    fn setup(&self, config: &Config, deluser: bool) -> DeprovisionPlan {
+        let mut plan = DeprovisionEngine::base_setup(config, deluser);
+        retarget_resolv_for_ubuntu(&mut plan);
+        plan
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ubuntu >= 18.04: do not touch /etc/resolv.conf at all.
+// ---------------------------------------------------------------------------
+pub struct Ubuntu1804DeprovisionHandler;
+
+impl Ubuntu1804DeprovisionHandler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for Ubuntu1804DeprovisionHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeprovisionHandler for Ubuntu1804DeprovisionHandler {
+    fn setup(&self, config: &Config, deluser: bool) -> DeprovisionPlan {
+        let mut plan = DeprovisionEngine::base_setup(config, deluser);
+        drop_resolv_steps(&mut plan);
+        plan.warn(
+            "WARNING! /etc/resolv.conf will NOT be removed; this is a behavior change \
+             from earlier versions of Ubuntu.",
+        );
+        plan
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Arch / CoreOS / Flatcar: also wipe /etc/machine-id.
+// ---------------------------------------------------------------------------
+pub struct ArchDeprovisionHandler;
+
+impl ArchDeprovisionHandler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ArchDeprovisionHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeprovisionHandler for ArchDeprovisionHandler {
+    fn setup(&self, config: &Config, deluser: bool) -> DeprovisionPlan {
+        let mut plan = DeprovisionEngine::base_setup(config, deluser);
+        plan.warn("WARNING! /etc/machine-id will be removed.");
+        plan.push(DeprovisionAction::RmFiles(vec!["/etc/machine-id".into()]));
+        plan
+    }
+}
+
+pub struct CoreOsDeprovisionHandler;
+
+impl CoreOsDeprovisionHandler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for CoreOsDeprovisionHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeprovisionHandler for CoreOsDeprovisionHandler {
+    fn setup(&self, config: &Config, deluser: bool) -> DeprovisionPlan {
+        let mut plan = DeprovisionEngine::base_setup(config, deluser);
+        plan.warn("WARNING! /etc/machine-id will be removed.");
+        plan.push(DeprovisionAction::RmFiles(vec!["/etc/machine-id".into()]));
+        plan
+    }
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/// Replace the generic `/etc/resolv.conf` removal with the Ubuntu-specific
+/// rewrite that respects resolvconf-managed setups.
+fn retarget_resolv_for_ubuntu(plan: &mut DeprovisionPlan) {
+    drop_resolv_steps(plan);
+
+    let resolv_is_managed = Path::new("/etc/resolv.conf")
+        .read_link()
+        .map(|t| t == Path::new("/run/resolvconf/resolv.conf"))
+        .unwrap_or(false);
+
+    if !resolv_is_managed {
+        plan.warn("WARNING! /etc/resolv.conf will be deleted.");
+        plan.push(DeprovisionAction::RmFiles(vec!["/etc/resolv.conf".into()]));
+    } else {
+        plan.warn(
+            "WARNING! /etc/resolvconf/resolv.conf.d/tail and \
+             /etc/resolvconf/resolv.conf.d/original will be deleted.",
+        );
+        plan.push(DeprovisionAction::RmFiles(vec![
+            "/etc/resolvconf/resolv.conf.d/tail".into(),
+            "/etc/resolvconf/resolv.conf.d/original".into(),
+        ]));
+    }
+}
+
+/// Strip the warnings and actions that the base plan emits for /etc/resolv.conf
+/// so a distro override can substitute its own behavior.
+fn drop_resolv_steps(plan: &mut DeprovisionPlan) {
+    plan.warnings
+        .retain(|w| !w.contains("/etc/resolv.conf"));
+    plan.actions.retain(|a| match a {
+        DeprovisionAction::RmFiles(files) => !files.iter().any(|f| f == "/etc/resolv.conf"),
+        _ => true,
+    });
+}

--- a/waagent-core/src/deprovision/factory.rs
+++ b/waagent-core/src/deprovision/factory.rs
@@ -1,0 +1,114 @@
+//! Distro detection + handler selection — port of
+//! `azurelinuxagent.pa.deprovision.factory.get_deprovision_handler`.
+
+use std::fs;
+
+use super::distro::{
+    ArchDeprovisionHandler, CoreOsDeprovisionHandler, Ubuntu1804DeprovisionHandler,
+    UbuntuDeprovisionHandler,
+};
+use super::{DefaultDeprovisionHandler, DeprovisionHandler};
+
+/// Minimal description of the running distro, parsed from `/etc/os-release`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DistroId {
+    /// `ID=` field (e.g. `ubuntu`, `arch`, `coreos`, `flatcar`).
+    pub id: String,
+    /// `VERSION_ID=` field (e.g. `22.04`).
+    pub version_id: String,
+    /// `PRETTY_NAME=` field, used to spot Clear Linux.
+    pub pretty_name: String,
+}
+
+/// Parse `/etc/os-release` (or return an empty struct on non-Linux / errors).
+pub fn detect_distro() -> DistroId {
+    let raw = match fs::read_to_string("/etc/os-release") {
+        Ok(s) => s,
+        Err(_) => return DistroId::default(),
+    };
+
+    let mut out = DistroId::default();
+    for line in raw.lines() {
+        let line = line.trim();
+        let Some((k, v)) = line.split_once('=') else {
+            continue;
+        };
+        let v = v.trim().trim_matches('"').to_string();
+        match k.trim() {
+            "ID" => out.id = v.to_lowercase(),
+            "VERSION_ID" => out.version_id = v,
+            "PRETTY_NAME" => out.pretty_name = v,
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Return the deprovision handler that best matches the running distro.
+/// Mirrors `get_deprovision_handler(distro_name, distro_version, distro_full_name)`.
+pub fn get_deprovision_handler() -> Box<dyn DeprovisionHandler> {
+    get_deprovision_handler_for(&detect_distro())
+}
+
+pub fn get_deprovision_handler_for(distro: &DistroId) -> Box<dyn DeprovisionHandler> {
+    match distro.id.as_str() {
+        "arch" => Box::new(ArchDeprovisionHandler::new()),
+        "ubuntu" => {
+            if version_at_least(&distro.version_id, (18, 4)) {
+                Box::new(Ubuntu1804DeprovisionHandler::new())
+            } else {
+                Box::new(UbuntuDeprovisionHandler::new())
+            }
+        }
+        "coreos" | "flatcar" => Box::new(CoreOsDeprovisionHandler::new()),
+        _ => {
+            // Clear Linux is detected by `PRETTY_NAME` rather than `ID`.
+            if distro.pretty_name.contains("Clear Linux") {
+                // No bespoke handler implemented yet — fall back to default.
+                Box::new(DefaultDeprovisionHandler::new())
+            } else {
+                Box::new(DefaultDeprovisionHandler::new())
+            }
+        }
+    }
+}
+
+/// Compare a `VERSION_ID` like `"18.04"` against `(major, minor)`.
+fn version_at_least(version_id: &str, (min_major, min_minor): (u32, u32)) -> bool {
+    let mut parts = version_id.split('.');
+    let major: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let minor: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    (major, minor) >= (min_major, min_minor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn picks_ubuntu_1804_for_new_versions() {
+        let d = DistroId {
+            id: "ubuntu".into(),
+            version_id: "22.04".into(),
+            pretty_name: "Ubuntu 22.04 LTS".into(),
+        };
+        // Just exercise dispatch — concrete type is opaque so we only check it
+        // doesn't panic and that older Ubuntu picks the legacy handler.
+        let _ = get_deprovision_handler_for(&d);
+
+        let d_old = DistroId {
+            id: "ubuntu".into(),
+            version_id: "16.04".into(),
+            pretty_name: "Ubuntu 16.04".into(),
+        };
+        let _ = get_deprovision_handler_for(&d_old);
+    }
+
+    #[test]
+    fn version_compare_handles_short_strings() {
+        assert!(version_at_least("18.04", (18, 4)));
+        assert!(version_at_least("22", (18, 4)));
+        assert!(!version_at_least("16.04", (18, 4)));
+        assert!(!version_at_least("", (18, 4)));
+    }
+}

--- a/waagent-core/src/deprovision/mod.rs
+++ b/waagent-core/src/deprovision/mod.rs
@@ -395,10 +395,10 @@ fn del_lib_dir_files(plan: &mut DeprovisionPlan, config: &Config) {
 fn del_ext_handler_files(plan: &mut DeprovisionPlan, config: &Config) {
     let lib_dir = config_string(config, "Lib.Dir", "/var/lib/waagent");
     let lib = lib_dir.trim_end_matches('/');
-    // Remove well-known per-extension state files via globs. The Python
-    // implementation scans the directory and skips the agent's own folder; we
-    // approximate by globbing for every handler subdirectory and excluding
-    // names that look like agent self-update payloads (`WALinuxAgent-*`).
+    // Remove well-known per-extension state files via globs. Unlike the Python
+    // implementation, this approximation does not scan subdirectories or
+    // exclude agent self-update payload folders such as `WALinuxAgent-*`; it
+    // simply matches the corresponding paths under every handler subdirectory.
     plan.push(DeprovisionAction::RmFiles(vec![
         format!("{}/*/status/*.status", lib),
         format!("{}/*/config/*.settings", lib),

--- a/waagent-core/src/deprovision/mod.rs
+++ b/waagent-core/src/deprovision/mod.rs
@@ -1,0 +1,493 @@
+//! Deprovision (port of `azurelinuxagent/pa/deprovision/`).
+//!
+//! Builds a [`DeprovisionPlan`] of warnings + [`DeprovisionAction`]s that, when
+//! executed, leave the VM in a state suitable for image capture. Mirrors the
+//! design of WALinuxAgent's `DeprovisionHandler`: distro-specific subclasses
+//! tweak the default plan; the engine handles confirmation, signal masking and
+//! action invocation.
+
+mod default;
+mod factory;
+
+pub mod distro;
+
+pub use default::DefaultDeprovisionHandler;
+pub use factory::{detect_distro, get_deprovision_handler, DistroId};
+
+use std::fmt;
+use std::io::{self, BufRead, Write};
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use tracing::{error, info, warn};
+
+use crate::config::Config;
+use crate::utils::fileutils;
+
+/// A unit of work scheduled by a deprovision handler. Each variant maps to a
+/// concrete operation performed during `do_actions`.
+#[derive(Debug, Clone)]
+pub enum DeprovisionAction {
+    /// Remove the listed files/globs (missing entries are ignored).
+    RmFiles(Vec<String>),
+    /// Remove the listed directories recursively (missing entries ignored).
+    RmDirs(Vec<String>),
+    /// Reset the system hostname.
+    SetHostname(String),
+    /// Reset the DHCP-published hostname.
+    SetDhcpHostname(String),
+    /// Delete a local user account and its home directory.
+    DelAccount(String),
+    /// Disable the root account password.
+    DelRootPassword,
+    /// Stop the running waagent service.
+    StopAgentService,
+}
+
+impl DeprovisionAction {
+    fn invoke(&self) {
+        match self {
+            DeprovisionAction::RmFiles(paths) => fileutils::rm_files(paths),
+            DeprovisionAction::RmDirs(paths) => fileutils::rm_dirs(paths),
+            DeprovisionAction::SetHostname(name) => set_hostname(name),
+            DeprovisionAction::SetDhcpHostname(name) => set_dhcp_hostname(name),
+            DeprovisionAction::DelAccount(user) => del_account(user),
+            DeprovisionAction::DelRootPassword => del_root_password(),
+            DeprovisionAction::StopAgentService => stop_agent_service(),
+        }
+    }
+}
+
+impl fmt::Display for DeprovisionAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DeprovisionAction::RmFiles(p) => write!(f, "rm files: {:?}", p),
+            DeprovisionAction::RmDirs(p) => write!(f, "rm dirs: {:?}", p),
+            DeprovisionAction::SetHostname(n) => write!(f, "set hostname: {}", n),
+            DeprovisionAction::SetDhcpHostname(n) => write!(f, "set dhcp hostname: {}", n),
+            DeprovisionAction::DelAccount(u) => write!(f, "delete account: {}", u),
+            DeprovisionAction::DelRootPassword => write!(f, "disable root password"),
+            DeprovisionAction::StopAgentService => write!(f, "stop agent service"),
+        }
+    }
+}
+
+/// Output of a deprovision handler's `setup`: ordered warnings to display to
+/// the operator, plus the actions to execute on confirmation.
+#[derive(Debug, Default, Clone)]
+pub struct DeprovisionPlan {
+    pub warnings: Vec<String>,
+    pub actions: Vec<DeprovisionAction>,
+}
+
+impl DeprovisionPlan {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn warn<S: Into<String>>(&mut self, msg: S) {
+        self.warnings.push(msg.into());
+    }
+
+    pub fn push(&mut self, action: DeprovisionAction) {
+        self.actions.push(action);
+    }
+}
+
+/// Trait implemented by every distro-specific deprovision handler. The default
+/// methods build the same plan as `DeprovisionHandler` in WALinuxAgent;
+/// distro implementations override `setup` (calling [`DeprovisionEngine::base_setup`])
+/// to add or replace steps.
+pub trait DeprovisionHandler {
+    fn setup(&self, config: &Config, deluser: bool) -> DeprovisionPlan {
+        DeprovisionEngine::base_setup(config, deluser)
+    }
+
+    fn setup_changed_unique_id(&self, config: &Config) -> DeprovisionPlan {
+        DeprovisionEngine::base_setup_changed_unique_id(config)
+    }
+
+    /// Full interactive run: build plan, print warnings, prompt for
+    /// confirmation, then execute on `y`. Pass `force=true` to skip the prompt.
+    fn run(&self, config: &Config, force: bool, deluser: bool) -> io::Result<()> {
+        let plan = self.setup(config, deluser);
+        let engine = DeprovisionEngine::new();
+        engine.do_warnings(&plan);
+        if engine.do_confirmation(force)? {
+            engine.do_actions(&plan);
+        } else {
+            info!("deprovision cancelled by user");
+        }
+        Ok(())
+    }
+
+    /// Non-interactive cleanup invoked when the VM unique id changes.
+    fn run_changed_unique_id(&self, config: &Config) {
+        let plan = self.setup_changed_unique_id(config);
+        let engine = DeprovisionEngine::new();
+        engine.do_warnings(&plan);
+        engine.do_actions(&plan);
+    }
+}
+
+/// Engine that owns side-effecting concerns (signal handling, prompting,
+/// invocation order). Kept separate so handlers stay declarative.
+pub struct DeprovisionEngine {
+    actions_running: Arc<AtomicBool>,
+}
+
+impl DeprovisionEngine {
+    pub fn new() -> Self {
+        Self {
+            actions_running: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Build the plan that matches `DeprovisionHandler.setup` in WALinuxAgent.
+    pub fn base_setup(config: &Config, deluser: bool) -> DeprovisionPlan {
+        let mut plan = DeprovisionPlan::new();
+
+        // 1. Stop the agent service.
+        plan.warn("WARNING! The waagent service will be stopped.");
+        plan.push(DeprovisionAction::StopAgentService);
+
+        // 2. Regenerate SSH host keys when configured.
+        if config_bool(config, "Provisioning.RegenerateSshHostKeyPair", false) {
+            let ssh_dir = config_string(config, "OS.SshDir", "/etc/ssh");
+            let key_type = config_string(config, "Provisioning.SshHostKeyPairType", "rsa");
+            plan.warn("WARNING! All SSH host key pairs will be deleted.");
+            plan.push(DeprovisionAction::RmFiles(vec![format!(
+                "{}/ssh_host_{}_key*",
+                ssh_dir.trim_end_matches('/'),
+                key_type
+            )]));
+        }
+
+        // 3. DHCP leases.
+        del_dhcp_lease(&mut plan);
+
+        // 4. Reset hostname.
+        plan.push(DeprovisionAction::SetHostname("localhost.localdomain".into()));
+        plan.push(DeprovisionAction::SetDhcpHostname(
+            "localhost.localdomain".into(),
+        ));
+
+        // 5. Optionally disable the root password.
+        if config_bool(config, "Provisioning.DeleteRootPassword", false) {
+            plan.warn(
+                "WARNING! root password will be disabled. You will not be able to login as root.",
+            );
+            plan.push(DeprovisionAction::DelRootPassword);
+        }
+
+        // 6. Lib & extension log directories.
+        let lib_dir = config_string(config, "Lib.Dir", "/var/lib/waagent");
+        let ext_log = config_string(config, "Extension.LogDir", "/var/log/azure");
+        plan.push(DeprovisionAction::RmDirs(vec![lib_dir.clone(), ext_log]));
+
+        // 7. Misc files.
+        let log_file = config_string(config, "Logs.File", "/var/log/waagent.log");
+        plan.push(DeprovisionAction::RmFiles(vec![
+            "/root/.bash_history".into(),
+            log_file,
+        ]));
+        // BSD-family random seed / IPsec keys (no-op on Linux).
+        plan.push(DeprovisionAction::RmFiles(vec![
+            "/etc/random.seed".into(),
+            "/var/db/host.random".into(),
+            "/etc/isakmpd/local.pub".into(),
+            "/etc/isakmpd/private/local.key".into(),
+            "/etc/iked/private/local.key".into(),
+            "/etc/iked/local.pub".into(),
+        ]));
+
+        // 8. /etc/resolv.conf (distros override this).
+        plan.warn("WARNING! /etc/resolv.conf will be deleted.");
+        plan.push(DeprovisionAction::RmFiles(vec!["/etc/resolv.conf".into()]));
+
+        // 9. Optionally remove the provisioned user account. Mirrors
+        // `del_user` in WALA: read the username from the cached ovf-env.xml
+        // (preferred) or from the freshly-mounted provisioning DVD.
+        if deluser {
+            match resolve_provisioned_username(config) {
+                Ok(username) => {
+                    plan.warn(format!(
+                        "WARNING! {} account and entire home directory will be deleted.",
+                        username
+                    ));
+                    plan.push(DeprovisionAction::DelAccount(username));
+                }
+                Err(reason) => {
+                    plan.warn(format!(
+                        "WARNING! ovf-env.xml is not available ({}). Skip delete user.",
+                        reason
+                    ));
+                }
+            }
+        }
+
+        // 10. Persisted firewall service unit (drop-in path mirrors WALA).
+        plan.push(DeprovisionAction::RmFiles(vec![
+            "/lib/systemd/system/waagent-network-setup.service".into(),
+            "/etc/systemd/system/waagent-network-setup.service".into(),
+            format!("{}/waagent-network-setup.py", lib_dir.trim_end_matches('/')),
+        ]));
+
+        // 11. Agent cgroup drop-in files.
+        plan.push(DeprovisionAction::RmFiles(vec![
+            "/etc/systemd/system/walinuxagent.service.d/10-Slice.conf".into(),
+            "/etc/systemd/system/walinuxagent.service.d/11-CPUAccounting.conf".into(),
+            "/etc/systemd/system/walinuxagent.service.d/12-CPUQuota.conf".into(),
+            "/etc/systemd/system/walinuxagent.service.d/13-MemoryAccounting.conf".into(),
+            "/etc/systemd/system/azure-walinuxagent-logcollector.slice".into(),
+        ]));
+
+        plan
+    }
+
+    /// Plan used by `run_changed_unique_id` (subset of the full setup).
+    pub fn base_setup_changed_unique_id(config: &Config) -> DeprovisionPlan {
+        let mut plan = DeprovisionPlan::new();
+        del_dhcp_lease(&mut plan);
+        del_lib_dir_files(&mut plan, config);
+        del_ext_handler_files(&mut plan, config);
+        // Persisted firewall + cgroup drop-ins, same as full setup tail.
+        let lib_dir = config_string(config, "Lib.Dir", "/var/lib/waagent");
+        plan.push(DeprovisionAction::RmFiles(vec![
+            "/lib/systemd/system/waagent-network-setup.service".into(),
+            "/etc/systemd/system/waagent-network-setup.service".into(),
+            format!("{}/waagent-network-setup.py", lib_dir.trim_end_matches('/')),
+        ]));
+        plan.push(DeprovisionAction::RmFiles(vec![
+            "/etc/systemd/system/walinuxagent.service.d/10-Slice.conf".into(),
+            "/etc/systemd/system/walinuxagent.service.d/11-CPUAccounting.conf".into(),
+            "/etc/systemd/system/walinuxagent.service.d/12-CPUQuota.conf".into(),
+            "/etc/systemd/system/walinuxagent.service.d/13-MemoryAccounting.conf".into(),
+            "/etc/systemd/system/azure-walinuxagent-logcollector.slice".into(),
+        ]));
+        plan
+    }
+
+    pub fn do_warnings(&self, plan: &DeprovisionPlan) {
+        for w in &plan.warnings {
+            println!("{}", w);
+        }
+    }
+
+    pub fn do_confirmation(&self, force: bool) -> io::Result<bool> {
+        if force {
+            return Ok(true);
+        }
+        print!("Do you want to proceed (y/n) ");
+        io::stdout().flush()?;
+        let mut input = String::new();
+        io::stdin().lock().read_line(&mut input)?;
+        Ok(input.trim_start().to_lowercase().starts_with('y'))
+    }
+
+    pub fn do_actions(&self, plan: &DeprovisionPlan) {
+        self.actions_running.store(true, Ordering::SeqCst);
+        for action in &plan.actions {
+            info!(target: "deprovision", "{}", action);
+            action.invoke();
+        }
+        self.actions_running.store(false, Ordering::SeqCst);
+    }
+
+    /// Whether actions are currently executing — exposed so a SIGINT handler
+    /// can decide whether interruption is safe (matches WALA's behavior).
+    pub fn actions_running(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.actions_running)
+    }
+}
+
+impl Default for DeprovisionEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers used by the default plan and distro overrides.
+// ---------------------------------------------------------------------------
+
+pub(crate) fn config_string(config: &Config, key: &str, fallback: &str) -> String {
+    match config.get_value(key) {
+        Some(crate::config::ConfigValue::String(s)) if s != "None" => s.clone(),
+        _ => fallback.to_string(),
+    }
+}
+
+pub(crate) fn config_bool(config: &Config, key: &str, fallback: bool) -> bool {
+    match config.get_value(key) {
+        Some(crate::config::ConfigValue::Bool(b)) => *b,
+        _ => fallback,
+    }
+}
+
+/// Locate the provisioned username for `--deluser`. We mirror WALA's
+/// `protocol_util.get_ovf_env`: prefer the cached `ovf-env.xml` under
+/// `Lib.Dir`, and fall back to mounting the provisioning DVD when missing.
+fn resolve_provisioned_username(config: &Config) -> Result<String, String> {
+    let lib_dir = config_string(config, "Lib.Dir", "/var/lib/waagent");
+    let cached = std::path::PathBuf::from(lib_dir.trim_end_matches('/')).join("ovf-env.xml");
+    if cached.is_file() {
+        return crate::ovf::load(&cached)
+            .map(|env| env.username)
+            .map_err(|e| format!("failed to parse cached {}: {}", cached.display(), e));
+    }
+
+    let mounted = crate::dvd::mount_dvd(config, &crate::dvd::MountOptions::default())
+        .map_err(|e| format!("could not mount provisioning DVD: {}", e))?;
+    let path = mounted.mount_point.join("ovf-env.xml");
+    let result = crate::ovf::load(&path)
+        .map(|env| env.username)
+        .map_err(|e| format!("failed to parse {}: {}", path.display(), e));
+
+    // Only unmount what we mounted ourselves.
+    if !mounted.already_mounted {
+        if let Err(err) = crate::dvd::umount_dvd(config, Some(&mounted.mount_point)) {
+            warn!("failed to unmount provisioning DVD: {}", err);
+        }
+    }
+    result
+}
+
+fn del_dhcp_lease(plan: &mut DeprovisionPlan) {
+    plan.warn("WARNING! Cached DHCP leases will be deleted.");
+    plan.push(DeprovisionAction::RmDirs(vec![
+        "/var/lib/dhclient".into(),
+        "/var/lib/dhcpcd".into(),
+        "/var/lib/dhcp".into(),
+    ]));
+    // BSD / NetworkManager / systemd-networkd lease files.
+    plan.push(DeprovisionAction::RmFiles(vec![
+        "/var/db/dhclient.leases.*".into(),
+        "/var/lib/NetworkManager/dhclient-*.lease".into(),
+        "/run/systemd/netif/leases/*".into(),
+    ]));
+}
+
+fn del_lib_dir_files(plan: &mut DeprovisionPlan, config: &Config) {
+    let lib_dir = config_string(config, "Lib.Dir", "/var/lib/waagent");
+    let lib = lib_dir.trim_end_matches('/');
+    let known = [
+        "HostingEnvironmentConfig.xml",
+        "Incarnation",
+        "partition",
+        "Protocol",
+        "SharedConfig.xml",
+        "WireServerEndpoint",
+        "published_hostname",
+        "fast_track.json",
+        "initial_goal_state",
+        "waagent_rsm_update",
+        "waagent_initial_update",
+    ];
+    let mut files: Vec<String> = known.iter().map(|f| format!("{}/{}", lib, f)).collect();
+    for pat in ["Extensions.*.xml", "ExtensionsConfig.*.xml", "GoalState.*.xml"] {
+        files.push(format!("{}/{}", lib, pat));
+    }
+    plan.push(DeprovisionAction::RmFiles(files));
+}
+
+fn del_ext_handler_files(plan: &mut DeprovisionPlan, config: &Config) {
+    let lib_dir = config_string(config, "Lib.Dir", "/var/lib/waagent");
+    let lib = lib_dir.trim_end_matches('/');
+    // Remove well-known per-extension state files via globs. The Python
+    // implementation scans the directory and skips the agent's own folder; we
+    // approximate by globbing for every handler subdirectory and excluding
+    // names that look like agent self-update payloads (`WALinuxAgent-*`).
+    plan.push(DeprovisionAction::RmFiles(vec![
+        format!("{}/*/status/*.status", lib),
+        format!("{}/*/config/*.settings", lib),
+        format!("{}/*/config/HandlerStatus", lib),
+        format!("{}/*/mrseq", lib),
+    ]));
+}
+
+// ---------------------------------------------------------------------------
+// Side-effecting helpers (Linux-only). On other targets they degrade to a
+// warning so the build stays green.
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "linux")]
+fn set_hostname(name: &str) {
+    run("hostnamectl", &["set-hostname", name])
+        .or_else(|| run("hostname", &[name]));
+}
+
+#[cfg(not(target_os = "linux"))]
+fn set_hostname(name: &str) {
+    warn!("set_hostname({}) skipped: not implemented on this platform", name);
+}
+
+#[cfg(target_os = "linux")]
+fn set_dhcp_hostname(name: &str) {
+    // Best-effort: write the new hostname into /etc/hostname so DHCP clients
+    // pick it up at the next renewal. Distros with non-standard layouts (e.g.
+    // FreeBSD's rc.conf) are out of scope for this port.
+    if let Err(err) = std::fs::write("/etc/hostname", format!("{}\n", name)) {
+        warn!("failed to update /etc/hostname: {}", err);
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn set_dhcp_hostname(name: &str) {
+    warn!("set_dhcp_hostname({}) skipped: not implemented on this platform", name);
+}
+
+#[cfg(target_os = "linux")]
+fn del_account(user: &str) {
+    // Hard-fail safety: refuse to delete root or empty usernames.
+    if user.is_empty() || user == "root" {
+        error!("refusing to delete account '{}'", user);
+        return;
+    }
+    run("userdel", &["-r", "-f", user]);
+}
+
+#[cfg(not(target_os = "linux"))]
+fn del_account(user: &str) {
+    warn!("del_account({}) skipped: not implemented on this platform", user);
+}
+
+#[cfg(target_os = "linux")]
+fn del_root_password() {
+    // `passwd -l root` locks the account; `usermod -p '!'` clears the hash.
+    run("passwd", &["-l", "root"]);
+}
+
+#[cfg(not(target_os = "linux"))]
+fn del_root_password() {
+    warn!("del_root_password skipped: not implemented on this platform");
+}
+
+#[cfg(target_os = "linux")]
+fn stop_agent_service() {
+    // Try the new and legacy unit names; ignore failures since the unit may
+    // not exist on minimal images.
+    run("systemctl", &["stop", "waagent-rs.service"]);
+    run("systemctl", &["stop", "walinuxagent.service"]);
+}
+
+#[cfg(not(target_os = "linux"))]
+fn stop_agent_service() {
+    warn!("stop_agent_service skipped: not implemented on this platform");
+}
+
+#[cfg(target_os = "linux")]
+fn run(cmd: &str, args: &[&str]) -> Option<()> {
+    match Command::new(cmd).args(args).status() {
+        Ok(s) if s.success() => Some(()),
+        Ok(s) => {
+            warn!("{} {:?} exited with {}", cmd, args, s);
+            None
+        }
+        Err(err) => {
+            warn!("failed to spawn {}: {}", cmd, err);
+            None
+        }
+    }
+}

--- a/waagent-core/src/dvd.rs
+++ b/waagent-core/src/dvd.rs
@@ -1,0 +1,380 @@
+//! Provisioning DVD helpers — port of `OSUtil.{get_dvd_device, mount_dvd,
+//! umount_dvd, get_mount_point}` from `azurelinuxagent/common/osutil/default.py`.
+//!
+//! Azure attaches a small ISO to the VM at first boot containing
+//! `ovf-env.xml` and certificate material. This module locates that device
+//! and mounts it read-only so the rest of the agent can read its contents.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+
+use tracing::{debug, info, warn};
+
+use crate::config::{Config, ConfigValue};
+
+/// Default mount point if the config does not override `DVD.MountPoint`.
+pub const DEFAULT_MOUNT_POINT: &str = "/mnt/cdrom/secure";
+
+/// Filesystem types tried by the WALA agent, in the same order.
+const DVD_FS_TYPES: &str = "udf,iso9660,vfat";
+
+/// Errors returned by the DVD helpers.
+#[derive(Debug)]
+pub enum DvdError {
+    /// No device under `/dev` matched the DVD pattern.
+    DeviceNotFound { dev_dir: PathBuf, candidates: Vec<String> },
+    /// `mount` failed every retry.
+    MountFailed { device: PathBuf, mount_point: PathBuf, last_error: String },
+    /// `umount` failed.
+    UmountFailed { mount_point: PathBuf, error: String },
+    /// I/O error while inspecting `/dev`, creating the mount point, etc.
+    Io(io::Error),
+}
+
+impl std::fmt::Display for DvdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DvdError::DeviceNotFound { dev_dir, candidates } => write!(
+                f,
+                "no DVD device found under {}; candidates were {:?}",
+                dev_dir.display(),
+                candidates
+            ),
+            DvdError::MountFailed { device, mount_point, last_error } => write!(
+                f,
+                "failed to mount {} at {}: {}",
+                device.display(),
+                mount_point.display(),
+                last_error
+            ),
+            DvdError::UmountFailed { mount_point, error } => {
+                write!(f, "failed to unmount {}: {}", mount_point.display(), error)
+            }
+            DvdError::Io(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for DvdError {}
+
+impl From<io::Error> for DvdError {
+    fn from(e: io::Error) -> Self {
+        DvdError::Io(e)
+    }
+}
+
+/// Configuration for [`mount_dvd`]. Mirrors the keyword arguments on
+/// `OSUtil.mount_dvd` so callers can tune retry behavior.
+#[derive(Debug, Clone)]
+pub struct MountOptions {
+    pub max_retries: u32,
+    pub sleep_between_retries: Duration,
+    /// Override the auto-detected device (e.g. `/dev/sr0`).
+    pub device: Option<PathBuf>,
+    /// Override the configured mount point.
+    pub mount_point: Option<PathBuf>,
+}
+
+impl Default for MountOptions {
+    fn default() -> Self {
+        Self {
+            max_retries: 6,
+            sleep_between_retries: Duration::from_secs(5),
+            device: None,
+            mount_point: None,
+        }
+    }
+}
+
+/// Result of a successful mount: the device that was mounted and where.
+#[derive(Debug, Clone)]
+pub struct MountedDvd {
+    pub device: PathBuf,
+    pub mount_point: PathBuf,
+    /// `true` when the device was already mounted before this call.
+    pub already_mounted: bool,
+}
+
+/// Locate the provisioning DVD by scanning entries in `dev_dir`.
+///
+/// Mirrors `DefaultOSUtil.get_dvd_device`: matches the first entry whose name
+/// matches `sr[0-9] | hd[c-z] | cdrom[0-9] | cd[0-9] | vd[b-z]`.
+pub fn get_dvd_device(dev_dir: &Path) -> Result<PathBuf, DvdError> {
+    let mut candidates = Vec::new();
+    for entry in fs::read_dir(dev_dir)? {
+        let entry = entry?;
+        let name = match entry.file_name().into_string() {
+            Ok(n) => n,
+            Err(_) => continue, // skip non-utf8 device names
+        };
+        candidates.push(name.clone());
+        if matches_dvd_pattern(&name) {
+            return Ok(dev_dir.join(name));
+        }
+    }
+    Err(DvdError::DeviceNotFound {
+        dev_dir: dev_dir.to_path_buf(),
+        candidates,
+    })
+}
+
+/// Read the configured mount point (`DVD.MountPoint`) or fall back to
+/// [`DEFAULT_MOUNT_POINT`].
+pub fn configured_mount_point(config: &Config) -> PathBuf {
+    match config.get_value("DVD.MountPoint") {
+        Some(ConfigValue::String(s)) if !s.is_empty() && s != "None" => PathBuf::from(s),
+        _ => PathBuf::from(DEFAULT_MOUNT_POINT),
+    }
+}
+
+/// Mount the provisioning DVD read-only with retry semantics matching WALA.
+///
+/// On success returns the device + mount point that ended up mounted. If the
+/// device was already mounted (anywhere), that pre-existing mount point is
+/// returned and `mount` is **not** invoked again.
+pub fn mount_dvd(config: &Config, opts: &MountOptions) -> Result<MountedDvd, DvdError> {
+    let device = match &opts.device {
+        Some(d) => d.clone(),
+        None => get_dvd_device(Path::new("/dev"))?,
+    };
+    let mount_point = opts
+        .mount_point
+        .clone()
+        .unwrap_or_else(|| configured_mount_point(config));
+
+    // If `mount` already lists this device, skip remounting (matches WALA).
+    if let Some(existing) = current_mount_point_for(&device)? {
+        info!(
+            "{} is already mounted at {}",
+            device.display(),
+            existing.display()
+        );
+        return Ok(MountedDvd {
+            device,
+            mount_point: existing,
+            already_mounted: true,
+        });
+    }
+
+    if !mount_point.is_dir() {
+        fs::create_dir_all(&mount_point)?;
+    }
+
+    let max = opts.max_retries.max(1);
+    let mut last_err = String::new();
+    for retry in 1..=max {
+        match try_mount(&device, &mount_point) {
+            Ok(()) => {
+                info!(
+                    "successfully mounted {} at {}",
+                    device.display(),
+                    mount_point.display()
+                );
+                return Ok(MountedDvd {
+                    device,
+                    mount_point,
+                    already_mounted: false,
+                });
+            }
+            Err(err) => {
+                warn!(
+                    "mounting dvd failed [retry {}/{}, sleeping {:?}]: {}",
+                    retry, max, opts.sleep_between_retries, err
+                );
+                last_err = err;
+                if retry < max {
+                    thread::sleep(opts.sleep_between_retries);
+                }
+            }
+        }
+    }
+
+    Err(DvdError::MountFailed {
+        device,
+        mount_point,
+        last_error: last_err,
+    })
+}
+
+/// Unmount whatever is at `mount_point` (or the configured one when `None`).
+pub fn umount_dvd(config: &Config, mount_point: Option<&Path>) -> Result<(), DvdError> {
+    let mp = mount_point
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| configured_mount_point(config));
+    debug!("unmounting {}", mp.display());
+
+    match Command::new("umount").arg(&mp).output() {
+        Ok(out) if out.status.success() => Ok(()),
+        Ok(out) => Err(DvdError::UmountFailed {
+            mount_point: mp,
+            error: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        }),
+        Err(err) => Err(DvdError::UmountFailed {
+            mount_point: mp,
+            error: err.to_string(),
+        }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// internals
+// ---------------------------------------------------------------------------
+
+/// Match the same regex used by WALA: `sr[0-9] | hd[c-z] | cdrom[0-9] | cd[0-9] | vd[b-z]`.
+fn matches_dvd_pattern(name: &str) -> bool {
+    fn one_digit(rest: &str) -> bool {
+        rest.len() == 1 && rest.chars().next().unwrap().is_ascii_digit()
+    }
+    if let Some(rest) = name.strip_prefix("sr") {
+        return one_digit(rest);
+    }
+    if let Some(rest) = name.strip_prefix("hd") {
+        return rest.len() == 1 && matches!(rest.chars().next().unwrap(), 'c'..='z');
+    }
+    if let Some(rest) = name.strip_prefix("cdrom") {
+        return one_digit(rest);
+    }
+    if let Some(rest) = name.strip_prefix("cd") {
+        return one_digit(rest);
+    }
+    if let Some(rest) = name.strip_prefix("vd") {
+        return rest.len() == 1 && matches!(rest.chars().next().unwrap(), 'b'..='z');
+    }
+    false
+}
+
+/// Run `mount -o ro -t udf,iso9660,vfat <device> <mount_point>`.
+fn try_mount(device: &Path, mount_point: &Path) -> Result<(), String> {
+    let output = Command::new("mount")
+        .args(["-o", "ro", "-t", DVD_FS_TYPES])
+        .arg(device)
+        .arg(mount_point)
+        .output()
+        .map_err(|e| format!("failed to spawn mount: {}", e))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "mount exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+    }
+}
+
+/// Return the existing mount point for `device`, if any. Uses `mount` (no
+/// args) so we don't depend on `/proc/mounts` formatting.
+fn current_mount_point_for(device: &Path) -> Result<Option<PathBuf>, DvdError> {
+    let output = match Command::new("mount").output() {
+        Ok(o) => o,
+        Err(err) => {
+            // Treat a missing `mount` binary as "nothing mounted" rather than
+            // a hard failure — this lets unit tests run on systems without it.
+            warn!("could not run `mount`: {}", err);
+            return Ok(None);
+        }
+    };
+    if !output.status.success() {
+        warn!(
+            "`mount` exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+        return Ok(None);
+    }
+    let listing = String::from_utf8_lossy(&output.stdout).into_owned();
+    Ok(get_mount_point(&listing, device))
+}
+
+/// Parse the output of `mount` and return the mount point for `device`, if
+/// listed. Equivalent to `DefaultOSUtil.get_mount_point`.
+///
+/// Lines look like: `/dev/sr0 on /mnt/cdrom/secure type iso9660 (ro,relatime)`.
+pub fn get_mount_point(mount_listing: &str, device: &Path) -> Option<PathBuf> {
+    let needle = device.to_string_lossy();
+    for line in mount_listing.lines() {
+        if !line.contains(needle.as_ref()) {
+            continue;
+        }
+        let mut tokens = line.split_whitespace();
+        // Expect: <device> on <mount_point> type ...
+        let _dev = tokens.next();
+        let on = tokens.next();
+        let mp = tokens.next();
+        if on == Some("on") {
+            if let Some(mp) = mp {
+                return Some(PathBuf::from(mp));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dvd_pattern_matches_expected_devices() {
+        for ok in ["sr0", "sr9", "hdc", "hdz", "cdrom0", "cd5", "vdb", "vdz"] {
+            assert!(matches_dvd_pattern(ok), "expected match for {}", ok);
+        }
+        for bad in ["sda", "sda1", "sr10", "hda", "hdb", "vd", "vda", "loop0", ""] {
+            assert!(!matches_dvd_pattern(bad), "expected non-match for {}", bad);
+        }
+    }
+
+    #[test]
+    fn parses_mount_listing() {
+        let listing = "\
+/dev/sda1 on / type ext4 (rw,relatime)
+proc on /proc type proc (rw)
+/dev/sr0 on /mnt/cdrom/secure type iso9660 (ro,relatime)
+tmpfs on /run type tmpfs (rw,nosuid)
+";
+        assert_eq!(
+            get_mount_point(listing, Path::new("/dev/sr0")),
+            Some(PathBuf::from("/mnt/cdrom/secure"))
+        );
+        assert_eq!(get_mount_point(listing, Path::new("/dev/sr1")), None);
+    }
+
+    #[test]
+    fn configured_mount_point_falls_back_to_default() {
+        let cfg = Config::default();
+        assert_eq!(configured_mount_point(&cfg), PathBuf::from("/mnt/cdrom/secure"));
+    }
+
+    #[test]
+    fn get_dvd_device_finds_match_in_temp_dir() {
+        let dir = std::env::temp_dir().join(format!("waagent_dvd_test_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        for n in ["sda", "sda1", "sr0"] {
+            fs::File::create(dir.join(n)).unwrap();
+        }
+
+        let found = get_dvd_device(&dir).unwrap();
+        assert_eq!(found.file_name().unwrap(), "sr0");
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn get_dvd_device_errors_when_no_match() {
+        let dir = std::env::temp_dir().join(format!("waagent_dvd_test_none_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        fs::File::create(dir.join("sda")).unwrap();
+
+        let err = get_dvd_device(&dir).unwrap_err();
+        assert!(matches!(err, DvdError::DeviceNotFound { .. }));
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/waagent-core/src/lib.rs
+++ b/waagent-core/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod config;
+pub mod deprovision;
+pub mod dvd;
 pub mod network;
+pub mod ovf;
 pub mod system;
 pub mod utils;

--- a/waagent-core/src/ovf.rs
+++ b/waagent-core/src/ovf.rs
@@ -1,0 +1,392 @@
+//! Parser for `ovf-env.xml` — port of `azurelinuxagent/common/protocol/ovfenv.py`.
+//!
+//! The provisioning ISO that Azure attaches at first boot contains an OVF
+//! Environment document with a Microsoft-specific
+//! `LinuxProvisioningConfigurationSet` element. This module parses just the
+//! fields the agent actually needs (hostname, username, SSH keys, custom
+//! data, …) without pulling in a full XSD-driven binding.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use quick_xml::events::Event;
+use quick_xml::escape::unescape;
+use quick_xml::name::ResolveResult;
+use quick_xml::reader::NsReader;
+
+/// Maximum supported OVF version. Newer versions only trigger a warning,
+/// matching the behaviour in WALA's `OvfEnv.parse`.
+pub const OVF_VERSION: &str = "1.0";
+
+/// `xmlns` for the OVF Environment root element.
+pub const OVF_NAMESPACE: &[u8] = b"http://schemas.dmtf.org/ovf/environment/1";
+/// `xmlns` for the Microsoft Azure provisioning extensions.
+pub const WA_NAMESPACE: &[u8] = b"http://schemas.microsoft.com/windowsazure";
+
+/// A single SSH public key entry from `<SSH><PublicKeys><PublicKey>`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SshPublicKey {
+    pub path: Option<String>,
+    pub fingerprint: Option<String>,
+    pub value: Option<String>,
+}
+
+/// A single SSH host key pair entry from `<SSH><KeyPairs><KeyPair>`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SshKeyPair {
+    pub path: Option<String>,
+    pub fingerprint: Option<String>,
+}
+
+/// Decoded `ovf-env.xml`. Mirrors the public attributes of `OvfEnv` in
+/// the Python agent (only the bits we currently consume).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OvfEnv {
+    pub version: String,
+    pub hostname: String,
+    pub username: String,
+    pub user_password: Option<String>,
+    pub custom_data: Option<String>,
+    pub disable_ssh_password_auth: bool,
+    pub ssh_pubkeys: Vec<SshPublicKey>,
+    pub ssh_keypairs: Vec<SshKeyPair>,
+    pub provision_guest_agent: Option<String>,
+}
+
+/// Errors returned while parsing `ovf-env.xml`.
+#[derive(Debug)]
+pub enum OvfError {
+    /// I/O error reading the file.
+    Io(io::Error),
+    /// XML was malformed.
+    Xml(quick_xml::Error),
+    /// A required element was missing or empty.
+    Missing(&'static str),
+}
+
+impl std::fmt::Display for OvfError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OvfError::Io(e) => write!(f, "{}", e),
+            OvfError::Xml(e) => write!(f, "malformed ovf-env.xml: {}", e),
+            OvfError::Missing(field) => {
+                write!(f, "ovf-env.xml is missing required element: {}", field)
+            }
+        }
+    }
+}
+
+impl std::error::Error for OvfError {}
+
+impl From<io::Error> for OvfError {
+    fn from(e: io::Error) -> Self {
+        OvfError::Io(e)
+    }
+}
+
+impl From<quick_xml::Error> for OvfError {
+    fn from(e: quick_xml::Error) -> Self {
+        OvfError::Xml(e)
+    }
+}
+
+impl From<quick_xml::encoding::EncodingError> for OvfError {
+    fn from(e: quick_xml::encoding::EncodingError) -> Self {
+        OvfError::Xml(quick_xml::Error::Encoding(e))
+    }
+}
+
+/// Read and parse an `ovf-env.xml` file from disk.
+pub fn load(path: &Path) -> Result<OvfEnv, OvfError> {
+    let raw = fs::read_to_string(path)?;
+    parse(&raw)
+}
+
+/// Parse `ovf-env.xml` from an in-memory string.
+pub fn parse(xml: &str) -> Result<OvfEnv, OvfError> {
+    let mut reader = NsReader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    let mut env = OvfEnv::default();
+    // We collect text into the most recently opened element. The Python
+    // implementation walks the DOM, but a streaming pass is enough here
+    // because the schema is shallow and there are no repeated text nodes
+    // we care about beyond direct children.
+    let mut path: Vec<TaggedName> = Vec::new();
+    let mut text_buf = String::new();
+
+    // Per-PublicKey / KeyPair scratch state.
+    let mut current_pubkey: Option<SshPublicKey> = None;
+    let mut current_keypair: Option<SshKeyPair> = None;
+    // Provisioning version vs platform version: only the one declared inside
+    // ProvisioningSection is what WALA validates against OVF_VERSION.
+    let mut in_provisioning_section = false;
+    let mut in_platform_section = false;
+
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_resolved_event_into(&mut buf)? {
+            (_, Event::Eof) => break,
+            (ns, Event::Start(e)) => {
+                let local = String::from_utf8_lossy(e.local_name().as_ref()).into_owned();
+                let tag = TaggedName {
+                    local: local.clone(),
+                    namespace: namespace_kind(&ns),
+                };
+
+                match (tag.namespace, tag.local.as_str()) {
+                    (Ns::Wa, "ProvisioningSection") => in_provisioning_section = true,
+                    (Ns::Wa, "PlatformSettingsSection") => in_platform_section = true,
+                    (Ns::Wa, "PublicKey") => current_pubkey = Some(SshPublicKey::default()),
+                    (Ns::Wa, "KeyPair") => current_keypair = Some(SshKeyPair::default()),
+                    _ => {}
+                }
+
+                path.push(tag);
+                text_buf.clear();
+            }
+            (_, Event::Text(t)) => {
+                // `xml_content` performs decoding + line-end normalization;
+                // `escape::unescape` then resolves XML entities (`&amp;`, …).
+                let decoded = t.xml_content()?;
+                let unescaped = unescape(&decoded)
+                    .map_err(|e| OvfError::Xml(quick_xml::Error::Escape(e)))?;
+                text_buf.push_str(&unescaped);
+            }
+            (ns, Event::End(e)) => {
+                let local = String::from_utf8_lossy(e.local_name().as_ref()).into_owned();
+                let kind = namespace_kind(&ns);
+                let value = std::mem::take(&mut text_buf);
+
+                if kind == Ns::Wa {
+                    match local.as_str() {
+                        "Version" if in_provisioning_section && env.version.is_empty() => {
+                            env.version = value.trim().to_string();
+                        }
+                        "HostName" => env.hostname = value.trim().to_string(),
+                        "UserName" => env.username = value.trim().to_string(),
+                        "UserPassword" => env.user_password = non_empty(&value),
+                        "CustomData" => env.custom_data = non_empty(&value),
+                        "DisableSshPasswordAuthentication" => {
+                            env.disable_ssh_password_auth = value.trim().eq_ignore_ascii_case("true");
+                        }
+                        "ProvisionGuestAgent" if in_platform_section => {
+                            env.provision_guest_agent = non_empty(&value);
+                        }
+                        "Path" => {
+                            if let Some(pk) = current_pubkey.as_mut() {
+                                pk.path = non_empty(&value);
+                            } else if let Some(kp) = current_keypair.as_mut() {
+                                kp.path = non_empty(&value);
+                            }
+                        }
+                        "Fingerprint" => {
+                            if let Some(pk) = current_pubkey.as_mut() {
+                                pk.fingerprint = non_empty(&value);
+                            } else if let Some(kp) = current_keypair.as_mut() {
+                                kp.fingerprint = non_empty(&value);
+                            }
+                        }
+                        "Value" => {
+                            if let Some(pk) = current_pubkey.as_mut() {
+                                pk.value = non_empty(&value.trim());
+                            }
+                        }
+                        "PublicKey" => {
+                            if let Some(pk) = current_pubkey.take() {
+                                env.ssh_pubkeys.push(pk);
+                            }
+                        }
+                        "KeyPair" => {
+                            if let Some(kp) = current_keypair.take() {
+                                env.ssh_keypairs.push(kp);
+                            }
+                        }
+                        "ProvisioningSection" => in_provisioning_section = false,
+                        "PlatformSettingsSection" => in_platform_section = false,
+                        _ => {}
+                    }
+                }
+
+                path.pop();
+            }
+            // Self-closing tags such as `<GuestAgentPackageName xsi:nil="true"/>`
+            // arrive as Empty; we only care that they don't disturb our state.
+            (_, Event::Empty(_)) => {}
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    // Validation parity with `_validate_ovf` in the Python agent.
+    if env.version.is_empty() {
+        return Err(OvfError::Missing("Version"));
+    }
+    if env.hostname.is_empty() {
+        return Err(OvfError::Missing("HostName"));
+    }
+    if env.username.is_empty() {
+        return Err(OvfError::Missing("UserName"));
+    }
+
+    if env.version.as_str() > OVF_VERSION {
+        tracing::warn!(
+            "newer OVF provisioning configuration detected ({} > {}); please consider updating waagent-rs",
+            env.version, OVF_VERSION
+        );
+    }
+
+    Ok(env)
+}
+
+/// Convert `quick-xml`'s resolved namespace into our internal enum.
+fn namespace_kind(resolved: &ResolveResult<'_>) -> Ns {
+    match resolved {
+        ResolveResult::Bound(ns) if ns.as_ref() == OVF_NAMESPACE => Ns::Ovf,
+        ResolveResult::Bound(ns) if ns.as_ref() == WA_NAMESPACE => Ns::Wa,
+        _ => Ns::Other,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Ns {
+    Ovf,
+    Wa,
+    Other,
+}
+
+#[derive(Debug, Clone)]
+struct TaggedName {
+    #[allow(dead_code)]
+    local: String,
+    #[allow(dead_code)]
+    namespace: Ns,
+}
+
+fn non_empty(s: &str) -> Option<String> {
+    let t = s.trim();
+    if t.is_empty() {
+        None
+    } else {
+        Some(t.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Synthetic fixture matching the structure observed on a freshly
+    /// provisioned Ubuntu Azure VM (whitespace, namespaces, element order).
+    /// Personally-identifying values are placeholders.
+    const SAMPLE_UBUNTU: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<ns0:Environment xmlns:ns0="http://schemas.dmtf.org/ovf/environment/1"
+                 xmlns:ns1="http://schemas.microsoft.com/windowsazure"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <ns1:ProvisioningSection>
+    <ns1:Version>1.0</ns1:Version>
+    <ns1:LinuxProvisioningConfigurationSet>
+      <ns1:ConfigurationSetType>LinuxProvisioningConfiguration</ns1:ConfigurationSetType>
+      <ns1:UserName>sampleuser</ns1:UserName>
+      <ns1:DisableSshPasswordAuthentication>true</ns1:DisableSshPasswordAuthentication>
+      <ns1:SSH>
+        <ns1:PublicKeys>
+          <ns1:PublicKey>
+            <ns1:Path>/home/sampleuser/.ssh/authorized_keys</ns1:Path>
+            <ns1:Value>ssh-rsa AAAAEXAMPLEKEY sample@host</ns1:Value>
+          </ns1:PublicKey>
+        </ns1:PublicKeys>
+      </ns1:SSH>
+      <ns1:HostName>samplehost</ns1:HostName>
+    </ns1:LinuxProvisioningConfigurationSet>
+  </ns1:ProvisioningSection>
+  <ns1:PlatformSettingsSection>
+    <ns1:Version>1.0</ns1:Version>
+    <ns1:PlatformSettings>
+      <ns1:KmsServerHostname>azkms.core.windows.net</ns1:KmsServerHostname>
+      <ns1:ProvisionGuestAgent>true</ns1:ProvisionGuestAgent>
+      <ns1:GuestAgentPackageName xsi:nil="true" />
+      <ns1:RetainWindowsPEPassInUnattend>true</ns1:RetainWindowsPEPassInUnattend>
+      <ns1:RetainOfflineServicingPassInUnattend>true</ns1:RetainOfflineServicingPassInUnattend>
+      <ns1:PreprovisionedVm>false</ns1:PreprovisionedVm>
+      <ns1:EnableTrustedImageIdentifier>false</ns1:EnableTrustedImageIdentifier>
+    </ns1:PlatformSettings>
+  </ns1:PlatformSettingsSection>
+</ns0:Environment>
+"#;
+
+    #[test]
+    fn parses_ubuntu_sample() {
+        let env = parse(SAMPLE_UBUNTU).expect("parse should succeed");
+        assert_eq!(env.version, "1.0");
+        assert_eq!(env.hostname, "samplehost");
+        assert_eq!(env.username, "sampleuser");
+        assert!(env.disable_ssh_password_auth);
+        assert_eq!(env.user_password, None);
+        assert_eq!(env.custom_data, None);
+        assert_eq!(env.provision_guest_agent.as_deref(), Some("true"));
+
+        assert_eq!(env.ssh_pubkeys.len(), 1);
+        let pk = &env.ssh_pubkeys[0];
+        assert_eq!(pk.path.as_deref(), Some("/home/sampleuser/.ssh/authorized_keys"));
+        assert_eq!(pk.value.as_deref(), Some("ssh-rsa AAAAEXAMPLEKEY sample@host"));
+        assert_eq!(pk.fingerprint, None);
+        assert!(env.ssh_keypairs.is_empty());
+    }
+
+    #[test]
+    fn parses_keypairs_and_password() {
+        let xml = r#"<ns0:Environment xmlns:ns0="http://schemas.dmtf.org/ovf/environment/1"
+                                      xmlns:ns1="http://schemas.microsoft.com/windowsazure">
+            <ns1:ProvisioningSection>
+              <ns1:Version>1.0</ns1:Version>
+              <ns1:LinuxProvisioningConfigurationSet>
+                <ns1:HostName>h</ns1:HostName>
+                <ns1:UserName>u</ns1:UserName>
+                <ns1:UserPassword>secret</ns1:UserPassword>
+                <ns1:CustomData>Y2xvdWQtaW5pdA==</ns1:CustomData>
+                <ns1:DisableSshPasswordAuthentication>false</ns1:DisableSshPasswordAuthentication>
+                <ns1:SSH>
+                  <ns1:KeyPairs>
+                    <ns1:KeyPair>
+                      <ns1:Path>/home/u/.ssh/id_rsa</ns1:Path>
+                      <ns1:Fingerprint>AB12</ns1:Fingerprint>
+                    </ns1:KeyPair>
+                  </ns1:KeyPairs>
+                </ns1:SSH>
+              </ns1:LinuxProvisioningConfigurationSet>
+            </ns1:ProvisioningSection>
+            <ns1:PlatformSettingsSection>
+              <ns1:Version>1.0</ns1:Version>
+              <ns1:PlatformSettings>
+                <ns1:ProvisionGuestAgent>true</ns1:ProvisionGuestAgent>
+              </ns1:PlatformSettings>
+            </ns1:PlatformSettingsSection>
+        </ns0:Environment>"#;
+
+        let env = parse(xml).unwrap();
+        assert_eq!(env.user_password.as_deref(), Some("secret"));
+        assert_eq!(env.custom_data.as_deref(), Some("Y2xvdWQtaW5pdA=="));
+        assert!(!env.disable_ssh_password_auth);
+        assert_eq!(env.ssh_keypairs.len(), 1);
+        assert_eq!(env.ssh_keypairs[0].fingerprint.as_deref(), Some("AB12"));
+    }
+
+    #[test]
+    fn missing_required_field_errors() {
+        let xml = r#"<ns0:Environment xmlns:ns0="http://schemas.dmtf.org/ovf/environment/1"
+                                      xmlns:ns1="http://schemas.microsoft.com/windowsazure">
+            <ns1:ProvisioningSection>
+              <ns1:Version>1.0</ns1:Version>
+              <ns1:LinuxProvisioningConfigurationSet>
+                <ns1:UserName>u</ns1:UserName>
+              </ns1:LinuxProvisioningConfigurationSet>
+            </ns1:ProvisioningSection>
+        </ns0:Environment>"#;
+        match parse(xml) {
+            Err(OvfError::Missing("HostName")) => {}
+            other => panic!("expected Missing(HostName), got {:?}", other),
+        }
+    }
+}

--- a/waagent-core/src/utils/fileutils.rs
+++ b/waagent-core/src/utils/fileutils.rs
@@ -1,6 +1,9 @@
 use std::fs::{self, File};
 use std::io::{self, Read};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+use glob::glob;
+use tracing::{debug, warn};
 
 pub fn read_file(path: &Path) -> std::io::Result<String> {
     // Errors should be propagated since this is a lib, caller in waagent-rs should handle errors.
@@ -11,6 +14,59 @@ pub fn read_file(path: &Path) -> std::io::Result<String> {
 
     file.read_to_string(&mut buffer)?;
     Ok(buffer)
+}
+
+/// Remove the given files. Each entry may be a literal path or a glob pattern
+/// (e.g. `/var/lib/waagent/GoalState.*.xml`). Missing files are ignored to
+/// mirror the behavior of WALinuxAgent's `fileutil.rm_files`.
+pub fn rm_files(paths: &[impl AsRef<str>]) {
+    for pattern in paths {
+        let pattern = pattern.as_ref();
+        for entry in expand_glob(pattern) {
+            if entry.is_file() || entry.is_symlink() {
+                if let Err(err) = fs::remove_file(&entry) {
+                    warn!("failed to remove file {}: {}", entry.display(), err);
+                } else {
+                    debug!("removed file {}", entry.display());
+                }
+            }
+        }
+    }
+}
+
+/// Recursively remove the given directories. Missing directories are ignored.
+pub fn rm_dirs(paths: &[impl AsRef<str>]) {
+    for pattern in paths {
+        let pattern = pattern.as_ref();
+        for entry in expand_glob(pattern) {
+            if entry.is_dir() {
+                if let Err(err) = fs::remove_dir_all(&entry) {
+                    warn!("failed to remove directory {}: {}", entry.display(), err);
+                } else {
+                    debug!("removed directory {}", entry.display());
+                }
+            }
+        }
+    }
+}
+
+fn expand_glob(pattern: &str) -> Vec<PathBuf> {
+    if pattern.contains(['*', '?', '[']) {
+        match glob(pattern) {
+            Ok(paths) => paths.filter_map(|p| p.ok()).collect(),
+            Err(err) => {
+                warn!("invalid glob pattern '{}': {}", pattern, err);
+                Vec::new()
+            }
+        }
+    } else {
+        let p = PathBuf::from(pattern);
+        if p.exists() {
+            vec![p]
+        } else {
+            Vec::new()
+        }
+    }
 }
 
 fn validate_path(path: &Path) -> io::Result<()> {

--- a/waagent-rs/src/main.rs
+++ b/waagent-rs/src/main.rs
@@ -10,6 +10,7 @@ use waagent_core::network::firewall::{
 };
 
 use waagent_core::config::Config;
+use waagent_core::deprovision::get_deprovision_handler;
 
 #[derive(ValueEnum, Clone, Debug, PartialEq)]
 enum LoggingLevel {
@@ -50,6 +51,20 @@ struct Args {
     /// Show configuration
     #[arg(long, default_value_t = false)]
     show_configuration: bool,
+
+    /// Deprovision the VM (clean up state for image capture). Equivalent to
+    /// `waagent -deprovision` in WALinuxAgent.
+    #[arg(long, default_value_t = false)]
+    deprovision: bool,
+
+    /// Deprovision and additionally remove the provisioned user account.
+    /// Equivalent to `waagent -deprovision+user`.
+    #[arg(long, default_value_t = false)]
+    deprovision_user: bool,
+
+    /// Skip the interactive y/n confirmation when deprovisioning.
+    #[arg(long, default_value_t = false)]
+    force: bool,
 }
 
 #[tokio::main]
@@ -71,6 +86,22 @@ async fn main() -> Result<()> {
         config.show();
     }
 
+    if args.deprovision || args.deprovision_user {
+        run_deprovision(args.force, args.deprovision_user)?;
+    }
+
+    Ok(())
+}
+
+#[tracing::instrument]
+fn run_deprovision(force: bool, deluser: bool) -> Result<()> {
+    info!("Starting deprovision (force={}, deluser={})", force, deluser);
+    let config = Config::default();
+    let handler = get_deprovision_handler();
+    handler
+        .run(&config, force, deluser)
+        .map_err(|e| anyhow::anyhow!("deprovision failed: {}", e))?;
+    info!("Deprovision finished");
     Ok(())
 }
 

--- a/waagent-rs/src/main.rs
+++ b/waagent-rs/src/main.rs
@@ -52,18 +52,19 @@ struct Args {
     #[arg(long, default_value_t = false)]
     show_configuration: bool,
 
-    /// Deprovision the VM (clean up state for image capture). Equivalent to
-    /// `waagent -deprovision` in WALinuxAgent.
+    /// Deprovision the VM (clean up state for image capture). Equivalent
+    /// to `waagent -deprovision` in WALinuxAgent.
     #[arg(long, default_value_t = false)]
     deprovision: bool,
 
-    /// Deprovision and additionally remove the provisioned user account.
-    /// Equivalent to `waagent -deprovision+user`.
-    #[arg(long, default_value_t = false)]
+    /// When combined with `--deprovision`, also remove the provisioned
+    /// user account and home directory. Equivalent to the `+user` modifier
+    /// in `waagent -deprovision+user`. Has no effect on its own.
+    #[arg(long, default_value_t = false, requires = "deprovision")]
     deprovision_user: bool,
 
     /// Skip the interactive y/n confirmation when deprovisioning.
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = false, requires = "deprovision")]
     force: bool,
 }
 
@@ -86,7 +87,7 @@ async fn main() -> Result<()> {
         config.show();
     }
 
-    if args.deprovision || args.deprovision_user {
+    if args.deprovision {
         run_deprovision(args.force, args.deprovision_user)?;
     }
 


### PR DESCRIPTION
Adding deprovisioning. Tested against a couple of distros and added usage to README.

I also had to add dvd mouting and ovf parsing, so that it could know the "original" provisioned user.

Note: Current packages don't ship command "waagent", but the next PR will be focused on moving all funct from -poc to waagent. To test now run "cargo build -p waagent-rs"