### PR TITLE
Add rust-toolchain.toml for Rust toolchain configuration

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
         language: [rust]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/deb-release.yml
+++ b/.github/workflows/deb-release.yml
@@ -20,7 +20,8 @@ jobs:
           - aarch64-unknown-linux-gnu
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rpm-release.yml
+++ b/.github/workflows/rpm-release.yml
@@ -70,7 +70,7 @@ jobs:
           $TOOL install rpmdevtools gcc ca-certificates pkg-config openssl-devel kernel-headers binutils glibc-devel
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Extract tag from Github
         run: |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.92"
+profile = "minimal"
+components = ["rustfmt", "clippy", "cargo"]


### PR DESCRIPTION
**Pin Rust toolchain to 1.92 with minimal profile**

Updates rust-toolchain.toml to pin the Rust toolchain to channel `1.92` instead of `stable`, switches to the `minimal` profile, and explicitly declares the required components (`rustfmt`, `clippy`, `cargo`).

**Why:**
- **Reproducible builds** — Pinning to a specific version (`1.92`) prevents unexpected breakages when a new stable release introduces compiler changes, lint additions, or behavioral differences. All developers and CI pipelines will use the same compiler version.
- **Minimal profile + explicit components** — The `default` profile installs components we may not need (e.g., `rust-docs`). Switching to `minimal` and listing only `rustfmt`, `clippy`, and `cargo` keeps the toolchain lean, speeds up installation in CI, and makes dependencies on specific components self-documenting.

Upgraded the checkout task to v5